### PR TITLE
Feature/client mod integration improvements

### DIFF
--- a/plugins/paper/src/main/java/com/playmonumenta/plugins/abilities/alchemist/AlchemistPotions.java
+++ b/plugins/paper/src/main/java/com/playmonumenta/plugins/abilities/alchemist/AlchemistPotions.java
@@ -292,6 +292,7 @@ public class AlchemistPotions extends Ability implements AbilityWithChargesOrSta
 				if (item != null) {
 					AbilityUtils.updateAlchemistItem(item, mCharges);
 				}
+				ClientModHandler.updateAbility(mPlayer, this);
 			}
 
 			if (item != null && item.getAmount() > 1 && ItemUtils.isAlchemistItem(item)) {

--- a/plugins/paper/src/main/java/com/playmonumenta/plugins/abilities/cleric/hierophant/ThuribleProcession.java
+++ b/plugins/paper/src/main/java/com/playmonumenta/plugins/abilities/cleric/hierophant/ThuribleProcession.java
@@ -108,6 +108,8 @@ public class ThuribleProcession extends Ability implements AbilityWithChargesOrS
 	//Recounts number of buffs and applies the passive ones
 	private void updateBuffs() {
 
+		int previousBuffs = mBuffs;
+
 		//Convert time into number of buffs and cap to maximum effect index for that level
 		mBuffs = mSeconds / 4;
 
@@ -116,7 +118,9 @@ public class ThuribleProcession extends Ability implements AbilityWithChargesOrS
 			mBuffs = MAX_BUFFS;
 		}
 
-		ClientModHandler.updateAbility(mPlayer, this);
+		if (previousBuffs != mBuffs) {
+			ClientModHandler.updateAbility(mPlayer, this);
+		}
 	}
 
 	//Applies built up buffs to all around them and themselves, take the duration as parameter (passive/built-up)

--- a/plugins/paper/src/main/java/com/playmonumenta/plugins/abilities/rogue/assassin/CloakAndDagger.java
+++ b/plugins/paper/src/main/java/com/playmonumenta/plugins/abilities/rogue/assassin/CloakAndDagger.java
@@ -11,8 +11,8 @@ import org.bukkit.entity.Projectile;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
-import org.bukkit.inventory.ItemStack;
 import org.bukkit.event.entity.EntityDeathEvent;
+import org.bukkit.inventory.ItemStack;
 
 import com.playmonumenta.plugins.Plugin;
 import com.playmonumenta.plugins.abilities.Ability;
@@ -140,10 +140,10 @@ public class CloakAndDagger extends Ability implements KillTriggeredAbility, Abi
 			} else {
 				mCloak++;
 			}
+			ClientModHandler.updateAbility(mPlayer, this);
 		}
 
 		MessagingUtils.sendActionBarMessage(mPlugin, mPlayer, "Cloak stacks: " + mCloak);
-		ClientModHandler.updateAbility(mPlayer, this);
 	}
 
 	@Override

--- a/plugins/paper/src/main/java/com/playmonumenta/plugins/abilities/rogue/swordsage/DeadlyRonde.java
+++ b/plugins/paper/src/main/java/com/playmonumenta/plugins/abilities/rogue/swordsage/DeadlyRonde.java
@@ -97,11 +97,11 @@ public class DeadlyRonde extends Ability implements AbilityWithChargesOrStacks {
 		if (mRondeStacks < maxStacks) {
 			mPlayer.playSound(mPlayer.getLocation(), Sound.ENTITY_PUFFER_FISH_BLOW_OUT, 1, 1f);
 			mPlayer.playSound(mPlayer.getLocation(), Sound.ENTITY_SNOW_GOLEM_DEATH, 0.7f, 1.5f);
+			mRondeStacks++;
+			ClientModHandler.updateAbility(mPlayer, this);
 		}
 
-		mRondeStacks = Math.min(mRondeStacks + 1, maxStacks);
 		MessagingUtils.sendActionBarMessage(mPlugin, mPlayer, "Deadly Ronde stacks: " + mRondeStacks);
-		ClientModHandler.updateAbility(mPlayer, this);
 
 		return true;
 	}

--- a/plugins/paper/src/main/java/com/playmonumenta/plugins/abilities/warrior/berserker/Rampage.java
+++ b/plugins/paper/src/main/java/com/playmonumenta/plugins/abilities/warrior/berserker/Rampage.java
@@ -119,33 +119,29 @@ public class Rampage extends Ability implements AbilityWithChargesOrStacks {
 	@Override
 	public boolean livingEntityDamagedByPlayerEvent(EntityDamageByEntityEvent event) {
 		if (event.getCause() == DamageCause.ENTITY_ATTACK) {
-			mTimeToStackDecay = 0;
-
-			mRemainderDamage += event.getFinalDamage();
-			int newStacks = mRemainderDamage / mDamagePerStack;
-			mRemainderDamage %= mDamagePerStack;
-
-			if (newStacks > 0) {
-				mStacks = Math.min(mStackLimit, mStacks + newStacks);
-				MessagingUtils.sendActionBarMessage(mPlugin, mPlayer, "Rage: " + mStacks);
-				ClientModHandler.updateAbility(mPlayer, this);
-			}
+			damageDealt(event.getFinalDamage());
 		}
-
 		return true;
 	}
 
 	public void customRecklessSwingInteraction(double swingDamage) {
+		damageDealt(swingDamage);
+	}
+
+	private void damageDealt(double damage) {
 		mTimeToStackDecay = 0;
 
-		mRemainderDamage += swingDamage;
+		mRemainderDamage += damage;
 		int newStacks = mRemainderDamage / mDamagePerStack;
 		mRemainderDamage %= mDamagePerStack;
 
 		if (newStacks > 0) {
+			int previousStacks = mStacks;
 			mStacks = Math.min(mStackLimit, mStacks + newStacks);
 			MessagingUtils.sendActionBarMessage(mPlugin, mPlayer, "Rage: " + mStacks);
-			ClientModHandler.updateAbility(mPlayer, this);
+			if (mStacks != previousStacks) {
+				ClientModHandler.updateAbility(mPlayer, this);
+			}
 		}
 	}
 

--- a/plugins/paper/src/main/java/com/playmonumenta/plugins/depths/DepthsTree.java
+++ b/plugins/paper/src/main/java/com/playmonumenta/plugins/depths/DepthsTree.java
@@ -1,5 +1,22 @@
 package com.playmonumenta.plugins.depths;
 
 public enum DepthsTree {
-	FROSTBORN, METALLIC, SUNLIGHT, EARTHBOUND, SHADOWS, WINDWALKER, FLAMECALLER
+	FROSTBORN("Frostborn"),
+	METALLIC("Steelsage"),
+	SUNLIGHT("Dawnbringer"),
+	EARTHBOUND("Earthbound"),
+	SHADOWS("Shadowdancer"),
+	WINDWALKER("Windwalker"),
+	FLAMECALLER("Flamecaller");
+
+	private final String displayName;
+
+	DepthsTree(String displayName) {
+		this.displayName = displayName;
+	}
+
+	public String getDisplayName() {
+		return displayName;
+	}
+
 }

--- a/plugins/paper/src/main/java/com/playmonumenta/plugins/listeners/PlayerListener.java
+++ b/plugins/paper/src/main/java/com/playmonumenta/plugins/listeners/PlayerListener.java
@@ -121,6 +121,7 @@ import com.playmonumenta.plugins.enchantments.infusions.Focus;
 import com.playmonumenta.plugins.enchantments.infusions.delves.Choler;
 import com.playmonumenta.plugins.events.AbilityCastEvent;
 import com.playmonumenta.plugins.events.EvasionEvent;
+import com.playmonumenta.plugins.network.ClientModHandler;
 import com.playmonumenta.plugins.point.Point;
 import com.playmonumenta.plugins.portals.PortalManager;
 import com.playmonumenta.plugins.potion.PotionManager.PotionID;
@@ -170,6 +171,14 @@ public class PlayerListener implements Listener {
 		//This checks to make sure that when you login you aren't stuck in blocks, just in case the lag that causes you to fall also kicks you. You don't want to be stuck in dirt forever, right?
 		Location loc = player.getLocation();
 		runTeleportRunnable(player, loc);
+
+		// Send class update to client mod. Needs to be delayed so that both abilities and the plugin channel are properly initialised.
+		new BukkitRunnable() {
+			@Override
+			public void run() {
+				ClientModHandler.updateAbilities(player);
+			}
+		}.runTaskLater(mPlugin, 10);
 	}
 
 	@EventHandler(priority = EventPriority.LOW)


### PR DESCRIPTION
One fix to properly send the class to the player on login, one additional client channel feature to send a skill's class to the client, and some cleanup to not send packets when it won't have an effect.

If my changes to DepthsTree are fine like this, I can also commit changes to DepthsUtils to use the names in the enum instead of the Strings repeated three times in that class.

PS: Please don't ask me why commit 32dc0d0e38214050e24535d22329aa8a0b70c144 is apparently part of this PR. I used Github's "fetch upstream" action and then based my new branch off my fork's master branch.