### PR TITLE
remove nested BlockEntityTags from shulker boxes

### DIFF
--- a/plugins/paper/src/main/java/com/playmonumenta/plugins/protocollib/VirtualItemsReplacer.java
+++ b/plugins/paper/src/main/java/com/playmonumenta/plugins/protocollib/VirtualItemsReplacer.java
@@ -291,17 +291,25 @@ public class VirtualItemsReplacer extends PacketAdapter {
 	private static void nestedShulkerCheck(ItemStack itemStack) {
 		// all shulkers should have a BlockEntityTag but check anyway
 		NBTCompound blockEntityTag = new NBTItem(itemStack, true).getCompound("BlockEntityTag");
-		if (blockEntityTag == null) return;
+		if (blockEntityTag == null) {
+			return;
+		}
 		NBTCompoundList items = blockEntityTag.getCompoundList("Items"); // this probably could be changed to ItemStatUtils.ITEMS_KEY but this is for vanilla
-		if (items == null) return;
+		if (items == null) {
+			return;
+		}
 		Boolean foundNested = false;
 		for (NBTCompound item : items) {
 			// we don't know if this is a container with a loottable! so check it
 			NBTCompound nestedBlockEntityTag = item.getCompound("BlockEntityTag");
-			if (nestedBlockEntityTag == null) continue;
+			if (nestedBlockEntityTag == null) {
+				continue;
+			}
 			// now check again if the Items tag exists
 			NBTCompoundList nestedItems = nestedBlockEntityTag.getCompoundList("Items");
-			if (nestedItems == null) continue;
+			if (nestedItems == null) {
+				continue;
+			}
 			foundNested = true;
 			nestedItems.clear();
 		}

--- a/plugins/paper/src/main/java/com/playmonumenta/plugins/protocollib/VirtualItemsReplacer.java
+++ b/plugins/paper/src/main/java/com/playmonumenta/plugins/protocollib/VirtualItemsReplacer.java
@@ -227,6 +227,27 @@ public class VirtualItemsReplacer extends PacketAdapter {
 			}
 		}
 
+		// Purge nested "Items" key in "BlockEntityTag" to prevent NBT banning
+		if (ItemUtils.isShulkerBox(itemStack.getType())) {
+			// all shulkers should have a BlockEntityTag but check anyway
+			NBTCompound blockEntityTag = new NBTItem(itemStack, true).getCompound("BlockEntityTag");
+			if (blockEntityTag != null) {
+				NBTCompoundList items = blockEntityTag.getCompoundList("Items"); // this probably could be changed to ItemStatUtils.ITEMS_KEY but this is for vanilla
+				for (NBTCompound item : items) {
+					// we don't know if this is a container with a loottable! so check it
+					NBTCompound nestedBlockEntityTag = item.getCompound("BlockEntityTag");
+					if (nestedBlockEntityTag != null) {
+						// now check again if the Items tag exists
+						NBTCompoundList nestedItems = nestedBlockEntityTag.getCompoundList("Items");
+						if (nestedItems != null) {
+							nestedItems.clear();
+							markVirtual(itemStack);
+						}
+					}
+				}
+			}
+		}
+
 		// Custom shulker names
 		if (ItemUtils.isShulkerBox(itemStack.getType())) {
 			String prefix;


### PR DESCRIPTION
From https://discord.com/channels/313066655494438922/329297351602601984/1110386079602843680

Njol this is your thing!

I thought it would be a feature that is pretty easy to do and may help in preventing shulker box/loot box bans.

Definitely needs testing but I don't have an updated SDK to test this on.
However, the plugin does compile.
