### PR TITLE
excavator no longer activates in plots

### DIFF
--- a/plugins/paper/src/main/java/com/playmonumenta/plugins/itemstats/enchantments/Excavator.java
+++ b/plugins/paper/src/main/java/com/playmonumenta/plugins/itemstats/enchantments/Excavator.java
@@ -43,6 +43,13 @@ public class Excavator implements Enchantment {
 			return;
 		}
 
+		if (ServerProperties.getShardName().equals("plots")) {
+			return;
+		}
+
+		// if anyone decides that disabling it in bazaar only is better:
+		// coords for corners of bz are -665, 46, 1054 to -650, 51, 1086
+
 		Block block = event.getBlock();
 		if (mIgnoredMats.contains(block.getType())) {
 			return;

--- a/plugins/paper/src/main/java/com/playmonumenta/plugins/overrides/AnvilOverride.java
+++ b/plugins/paper/src/main/java/com/playmonumenta/plugins/overrides/AnvilOverride.java
@@ -2,6 +2,7 @@ package com.playmonumenta.plugins.overrides;
 
 import com.playmonumenta.plugins.Constants;
 import com.playmonumenta.plugins.Plugin;
+import com.playmonumenta.plugins.integrations.CoreProtectIntegration;
 import com.playmonumenta.plugins.itemstats.infusions.Shattered;
 import com.playmonumenta.plugins.utils.ItemStatUtils;
 import com.playmonumenta.plugins.utils.ItemStatUtils.EnchantmentType;
@@ -76,6 +77,7 @@ public class AnvilOverride extends BaseOverride {
 					}
 
 				}.runTaskTimer(plugin, 0, 7);
+				CoreProtectIntegration.logRemoval(player, block);
 				block.setType(Material.AIR);
 				block.removeMetadata(Constants.ANVIL_CONFIRMATION_METAKEY, plugin);
 				int repCount = ScoreboardUtils.getScoreboardValue(player, REPAIR_OBJECTIVE).orElse(0) + 1;


### PR DESCRIPTION
suggestion 8511: "Disable veilripper in market. Players accidentally break other players signs in bazaar."