### PR TITLE
Class gui rp support

### DIFF
--- a/plugins/paper/src/main/java/com/playmonumenta/plugins/abilities/AbilityTrigger.java
+++ b/plugins/paper/src/main/java/com/playmonumenta/plugins/abilities/AbilityTrigger.java
@@ -125,6 +125,7 @@ public class AbilityTrigger {
 			mDisabledDisplay = disabledDisplay;
 			mMaterial = material;
 			mPredicate = predicate;
+			mGuiTag = "unassigned";
 		}
 
 		KeyOptions(String enabledDisplay, String disabledDisplay, Material material, Predicate<Player> predicate, String guiTag) {

--- a/plugins/paper/src/main/java/com/playmonumenta/plugins/abilities/AbilityTrigger.java
+++ b/plugins/paper/src/main/java/com/playmonumenta/plugins/abilities/AbilityTrigger.java
@@ -63,35 +63,37 @@ public class AbilityTrigger {
 
 	public enum KeyOptions {
 		NO_POTION("not holding a potion", "may be holding a potion", Material.POTION,
-			player -> !ItemUtils.isSomePotion(player.getInventory().getItemInMainHand())),
+			player -> !ItemUtils.isSomePotion(player.getInventory().getItemInMainHand()), "hold_potion"),
 		NO_FOOD("not holding food", "may be holding food", Material.COOKED_BEEF,
-			player -> !player.getInventory().getItemInMainHand().getType().isEdible()),
+			player -> !player.getInventory().getItemInMainHand().getType().isEdible(), "hold_food"),
 		NO_PROJECTILE_WEAPON("not holding a projectile weapon", "may be holding a projectile weapon", Material.CROSSBOW,
-			player -> !ItemUtils.isShootableItem(player.getInventory().getItemInMainHand())),
+			player -> !ItemUtils.isShootableItem(player.getInventory().getItemInMainHand()), "hold_proj"),
 		NO_SHIELD("not holding a shield", "may be holding a shield", Material.SHIELD,
-			player -> player.getInventory().getItemInMainHand().getType() != Material.SHIELD),
+			player -> player.getInventory().getItemInMainHand().getType() != Material.SHIELD, "hold_shield"),
 		NO_BLOCKS("not holding blocks", "may be holding blocks", Material.COBBLESTONE,
 			player -> {
 				ItemStack mainhand = player.getInventory().getItemInMainHand();
 				return !mainhand.getType().isBlock() || ItemUtils.isWand(mainhand);
-			}),
+			},
+			"hold_block"),
 		NO_MISC("not holding a compass, a multitool, or a riptide trident while swimming", "may be holding a compass, a multitool, or a riptide trident while swimming", Material.COMPASS,
 			player -> {
 				ItemStack mainhand = player.getInventory().getItemInMainHand();
 				return !(mainhand.getType() == Material.COMPASS
 					|| ItemStatUtils.hasEnchantment(mainhand, EnchantmentType.MULTITOOL)
 					|| PlayerUtils.canRiptide(player, mainhand));
-			}),
+			},
+			"hold_util"),
 		NO_PICKAXE("not holding a pickaxe", "may be holding a pickaxe", Material.IRON_PICKAXE,
-			player -> !ItemUtils.isPickaxe(player.getInventory().getItemInMainHand())),
+			player -> !ItemUtils.isPickaxe(player.getInventory().getItemInMainHand()), "hold_pickaxe"),
 		NO_SHOVEL("not holding a shovel", "may be holding a shovel", Material.IRON_SHOVEL,
-			player -> !ItemUtils.isShovel(player.getInventory().getItemInMainHand())),
+			player -> !ItemUtils.isShovel(player.getInventory().getItemInMainHand()), "hold_shovel"),
 		NO_AXE("not holding an axe", "may be holding an axe", Material.IRON_AXE,
-			player -> !ItemUtils.isAxe(player.getInventory().getItemInMainHand())),
+			player -> !ItemUtils.isAxe(player.getInventory().getItemInMainHand()), "hold_axe"),
 		REQUIRE_PROJECTILE_WEAPON("holding a projectile weapon", "may be not holding a projectile weapon", Material.CROSSBOW,
-			player -> ItemUtils.isShootableItem(player.getInventory().getItemInMainHand())),
+			player -> ItemUtils.isShootableItem(player.getInventory().getItemInMainHand()), "hold_proj_force"),
 		SNEAK_WITH_SHIELD("sneaking if holding a shield", "no sneak requirement if holding a shield", Material.SHIELD,
-			player -> player.isSneaking() || !(player.getInventory().getItemInMainHand().getType() == Material.SHIELD || player.getInventory().getItemInOffHand().getType() == Material.SHIELD)),
+			player -> player.isSneaking() || !(player.getInventory().getItemInMainHand().getType() == Material.SHIELD || player.getInventory().getItemInOffHand().getType() == Material.SHIELD), "sneak_shield"),
 		;
 
 		public static final KeyOptions[] NO_USABLE_ITEMS = {
@@ -115,6 +117,8 @@ public class AbilityTrigger {
 		private final String mDisabledDisplay;
 		private final Material mMaterial;
 		private final Predicate<Player> mPredicate;
+		// tag used for rp support
+		private final String mGuiTag;
 
 		KeyOptions(String enabledDisplay, String disabledDisplay, Material material, Predicate<Player> predicate) {
 			mEnabledDisplay = enabledDisplay;
@@ -123,12 +127,24 @@ public class AbilityTrigger {
 			mPredicate = predicate;
 		}
 
+		KeyOptions(String enabledDisplay, String disabledDisplay, Material material, Predicate<Player> predicate, String guiTag) {
+			mEnabledDisplay = enabledDisplay;
+			mDisabledDisplay = disabledDisplay;
+			mMaterial = material;
+			mPredicate = predicate;
+			mGuiTag = guiTag;
+		}
+
 		public String getDisplay(boolean enabled) {
 			return enabled ? mEnabledDisplay : mDisabledDisplay;
 		}
 
 		public Material getMaterial() {
 			return mMaterial;
+		}
+
+		public String getGuiTag(boolean enabled) {
+			return mGuiTag + (enabled ? "_true" : "_false");
 		}
 
 		@Override

--- a/plugins/paper/src/main/java/com/playmonumenta/plugins/abilities/AbilityTrigger.java
+++ b/plugins/paper/src/main/java/com/playmonumenta/plugins/abilities/AbilityTrigger.java
@@ -145,7 +145,7 @@ public class AbilityTrigger {
 		}
 
 		public String getGuiTag(boolean enabled) {
-			return mGuiTag + (enabled ? "_true" : "_false");
+			return mGuiTag + (enabled ? "true" : "false");
 		}
 
 		@Override

--- a/plugins/paper/src/main/java/com/playmonumenta/plugins/custominventories/ClassSelectionCustomInventory.java
+++ b/plugins/paper/src/main/java/com/playmonumenta/plugins/custominventories/ClassSelectionCustomInventory.java
@@ -762,7 +762,7 @@ public class ClassSelectionCustomInventory extends CustomInventory {
 			int currentEnhanceCount = ScoreboardUtils.getScoreboardValue(player, AbilityUtils.REMAINING_ENHANCE);
 			ItemStack summaryItem = GUIUtils.createBasicItem(currentEnhanceCount == 0 ? Material.BARRIER : Material.ENCHANTING_TABLE, "Enhancement Points", NamedTextColor.WHITE, false,
 				"You have " + currentEnhanceCount + " enhancement point" + (currentEnhanceCount == 1 ? "" : "s") + " remaining.", NamedTextColor.LIGHT_PURPLE);
-			GUIUtils.setGuiNbtTag(summaryItem, "texture", "cross_gui_total_en" + currentEnhanceCount == 0 ? "_none" : "");
+			GUIUtils.setGuiNbtTag(summaryItem, "texture", "cross_gui_total_en" + (currentEnhanceCount == 0 ? "_none" : ""));
 			summaryItem.setAmount(currentEnhanceCount > 0 ? currentEnhanceCount : 1);
 			mInventory.setItem(COMMON_REMAINING_ENHANCEMENTS_LOC, summaryItem);
 		}
@@ -770,14 +770,14 @@ public class ClassSelectionCustomInventory extends CustomInventory {
 			int currentSpecCount = ScoreboardUtils.getScoreboardValue(player, AbilityUtils.REMAINING_SPEC);
 			ItemStack summaryItem = GUIUtils.createBasicItem(currentSpecCount == 0 ? Material.BARRIER : Material.SAND, "Specialization Points", NamedTextColor.WHITE, false,
 				"You have " + currentSpecCount + " specialization point" + (currentSpecCount == 1 ? "" : "s") + " remaining.", NamedTextColor.LIGHT_PURPLE);
-			GUIUtils.setGuiNbtTag(summaryItem, "texture", "cross_gui_total_spec" + currentSpecCount == 0 ? "_none" : "");
+			GUIUtils.setGuiNbtTag(summaryItem, "texture", "cross_gui_total_spec" + (currentSpecCount == 0 ? "_none" : ""));
 			summaryItem.setAmount(currentSpecCount > 0 ? currentSpecCount : 1);
 			mInventory.setItem(COMMON_REMAINING_SPEC_LOC, summaryItem);
 		}
 		int currentSkillCount = ScoreboardUtils.getScoreboardValue(player, AbilityUtils.REMAINING_SKILL);
 		ItemStack summaryItem = GUIUtils.createBasicItem(currentSkillCount == 0 ? Material.BARRIER : Material.ROOTED_DIRT, "Skill Points", NamedTextColor.WHITE, false,
 			"You have " + currentSkillCount + " skill point" + (currentSkillCount == 1 ? "" : "s") + " remaining.", NamedTextColor.LIGHT_PURPLE);
-		GUIUtils.setGuiNbtTag(summaryItem, "texture", "cross_gui_total_sp" + currentSkillCount == 0 ? "_none" : "");
+		GUIUtils.setGuiNbtTag(summaryItem, "texture", "cross_gui_total_sp" + (currentSkillCount == 0 ? "_none" : ""));
 		summaryItem.setAmount(currentSkillCount > 0 ? currentSkillCount : 1);
 		mInventory.setItem(COMMON_REMAINING_SKILL_LOC, summaryItem);
 	}

--- a/plugins/paper/src/main/java/com/playmonumenta/plugins/custominventories/ClassSelectionCustomInventory.java
+++ b/plugins/paper/src/main/java/com/playmonumenta/plugins/custominventories/ClassSelectionCustomInventory.java
@@ -344,7 +344,11 @@ public class ClassSelectionCustomInventory extends CustomInventory {
 		}
 
 		// set gui identifier
-		mInventory.setItem(GUI_IDENTIFIER_LOC, GUIUtils.createGuiIdentifierItem("gui_class_2"));
+		ItemStack guiIdentifier = GUIUtils.createGuiIdentifierItem("gui_class_2_1");
+		GUIUtils.setGuiNbtTag(guiIdentifier, "class", userClass.mClassName);
+		GUIUtils.setGuiNbtTag(guiIdentifier, "spec",
+			(spec == 0) ? "none" : (spec == userClass.mSpecOne.mSpecialization ? userClass.mSpecOne : userClass.mSpecTwo).mSpecName);
+		mInventory.setItem(GUI_IDENTIFIER_LOC, guiIdentifier);
 
 		makeRemainingCountItems(player);
 		fillEmptyAndSetPlainTags();
@@ -389,17 +393,22 @@ public class ClassSelectionCustomInventory extends CustomInventory {
 		mInventory.setItem(COMMON_BACK_LOC, backButton);
 
 		//possibly create reset spec item
-		if (ScoreboardUtils.getScoreboardValue(player, AbilityUtils.SCOREBOARD_SPEC_NAME) != 0) {
+		int spec = ScoreboardUtils.getScoreboardValue(player, AbilityUtils.SCOREBOARD_SPEC_NAME);
+		if (spec != 0) {
 			ItemStack specItem = GUIUtils.createBasicItem(Material.RED_BANNER, "Reset Your Specialization", NamedTextColor.WHITE, false,
 				"Click here to reset your specialization to select a new one.", NamedTextColor.LIGHT_PURPLE);
 			GUIUtils.setGuiNbtTag(specItem, "texture", "cross_gui_reset_spec");
 			GUIUtils.setGuiNbtTag(specItem, "Spec",
-				(ScoreboardUtils.getScoreboardValue(player, AbilityUtils.SCOREBOARD_SPEC_NAME) == userClass.mSpecOne.mSpecialization ? userClass.mSpecOne : userClass.mSpecTwo).mSpecName);
+				(spec == userClass.mSpecOne.mSpecialization ? userClass.mSpecOne : userClass.mSpecTwo).mSpecName);
 			mInventory.setItem(SKILL_PAGE_RESET_SPEC_LOC, specItem);
 		}
 
 		// set gui identifier
-		mInventory.setItem(GUI_IDENTIFIER_LOC, GUIUtils.createGuiIdentifierItem("gui_class_2"));
+		ItemStack guiIdentifier = GUIUtils.createGuiIdentifierItem("gui_class_2_2");
+		GUIUtils.setGuiNbtTag(guiIdentifier, "class", userClass.mClassName);
+		GUIUtils.setGuiNbtTag(guiIdentifier, "spec",
+			(spec == 0) ? "none" : (spec == userClass.mSpecOne.mSpecialization ? userClass.mSpecOne : userClass.mSpecTwo).mSpecName);
+		mInventory.setItem(GUI_IDENTIFIER_LOC, guiIdentifier);
 
 		makeRemainingCountItems(player);
 		fillEmptyAndSetPlainTags();
@@ -430,7 +439,10 @@ public class ClassSelectionCustomInventory extends CustomInventory {
 		mInventory.setItem(COMMON_BACK_LOC, backButton);
 
 		// set gui identifier
-		mInventory.setItem(GUI_IDENTIFIER_LOC, GUIUtils.createGuiIdentifierItem("gui_class_3"));
+		ItemStack guiIdentifier = GUIUtils.createGuiIdentifierItem("gui_class_3");
+		GUIUtils.setGuiNbtTag(guiIdentifier, "class", userClass.mClassName);
+		GUIUtils.setGuiNbtTag(guiIdentifier, "spec", spec.mSpecName);
+		mInventory.setItem(GUI_IDENTIFIER_LOC, guiIdentifier);
 
 		makeRemainingCountItems(player);
 		fillEmptyAndSetPlainTags();
@@ -644,6 +656,8 @@ public class ClassSelectionCustomInventory extends CustomInventory {
 		} else {
 			GUIUtils.setGuiNbtTag(levelItem, "texture", "skill_select_" + (getScore >= level ? "sp_lit" : "sp_unlit"));
 		}
+		GUIUtils.setGuiNbtTag(levelItem, "skill", ability.getDisplayName());
+		GUIUtils.setGuiNbtTag(levelItem, "level",  "" + level);
 		return levelItem;
 	}
 

--- a/plugins/paper/src/main/java/com/playmonumenta/plugins/custominventories/ClassSelectionCustomInventory.java
+++ b/plugins/paper/src/main/java/com/playmonumenta/plugins/custominventories/ClassSelectionCustomInventory.java
@@ -44,16 +44,13 @@ public class ClassSelectionCustomInventory extends CustomInventory {
 	public static final ArrayList<Integer> SKILL_PAGE_SPEC_LOCS = new ArrayList<>(Arrays.asList(47, 51));
 	private static final int SKILL_PAGE_RESET_SPEC_LOC = 49;
 
-	private static final ArrayList<Integer> P3_ABILITY_LOCS = new ArrayList<>(Arrays.asList(9, 14, 18, 23, 27, 32, 36, 41));
+	private static final ArrayList<Integer> P3_ABILITY_LOCS = new ArrayList<>(Arrays.asList(10, 14, 19, 23, 28, 32, 37, 41));
 
 	/**
 	 *  gui identifiers are used for rp to put a texture to a gui. they would be unique to each gui and work
 	 *  pretty much like a filler.
 	 */
-	private static final int P1_GUI_IDENTIFIER_LOC = 45;
-	private static final int P2_GUI_IDENTIFIER_LOC = 45;
-	private static final int P3_GUI_IDENTIFIER_LOC = 45;
-	private static final int P4_GUI_IDENTIFIER_LOC = 45;
+	private static final int GUI_IDENTIFIER_LOC = 45;
 
 	public static final ArrayList<Integer> P4_SPEC_LOCS = new ArrayList<>(Arrays.asList(20, 30, 40));
 	private static final MonumentaClasses mClasses = new MonumentaClasses();
@@ -288,7 +285,7 @@ public class ClassSelectionCustomInventory extends CustomInventory {
 		mInventory.setItem(P1_CHANGE_TRIGGERS_LOC, triggersItem);
 
 		// set gui identifier
-		mInventory.setItem(P1_GUI_IDENTIFIER_LOC, GUIUtils.createGuiIdentifierItem("gui_class_1"));
+		mInventory.setItem(GUI_IDENTIFIER_LOC, GUIUtils.createGuiIdentifierItem("gui_class_1"));
 
 		makeRemainingCountItems(player);
 		fillEmptyAndSetPlainTags();
@@ -347,7 +344,7 @@ public class ClassSelectionCustomInventory extends CustomInventory {
 		}
 
 		// set gui identifier
-		mInventory.setItem(P1_GUI_IDENTIFIER_LOC, GUIUtils.createGuiIdentifierItem("gui_class_2"));
+		mInventory.setItem(GUI_IDENTIFIER_LOC, GUIUtils.createGuiIdentifierItem("gui_class_2"));
 
 		makeRemainingCountItems(player);
 		fillEmptyAndSetPlainTags();
@@ -402,7 +399,7 @@ public class ClassSelectionCustomInventory extends CustomInventory {
 		}
 
 		// set gui identifier
-		mInventory.setItem(P1_GUI_IDENTIFIER_LOC, GUIUtils.createGuiIdentifierItem("gui_class_2"));
+		mInventory.setItem(GUI_IDENTIFIER_LOC, GUIUtils.createGuiIdentifierItem("gui_class_2"));
 
 		makeRemainingCountItems(player);
 		fillEmptyAndSetPlainTags();
@@ -433,7 +430,7 @@ public class ClassSelectionCustomInventory extends CustomInventory {
 		mInventory.setItem(COMMON_BACK_LOC, backButton);
 
 		// set gui identifier
-		mInventory.setItem(P1_GUI_IDENTIFIER_LOC, GUIUtils.createGuiIdentifierItem("gui_class_3"));
+		mInventory.setItem(GUI_IDENTIFIER_LOC, GUIUtils.createGuiIdentifierItem("gui_class_3"));
 
 		makeRemainingCountItems(player);
 		fillEmptyAndSetPlainTags();
@@ -650,29 +647,11 @@ public class ClassSelectionCustomInventory extends CustomInventory {
 		return levelItem;
 	}
 
-	public ItemStack createLevelItem(PlayerClass theClass, AbilityInfo<?> ability, int level, Player player) {
-		int getScore;
-		String scoreboard = ability.getScoreboard();
-		if (scoreboard == null) {
-			getScore = 0;
-		} else {
-			getScore = ScoreboardUtils.getScoreboardValue(player, scoreboard);
-			if (getScore > 2) {
-				getScore -= 2;
-			}
-		}
-		Material newMat = getScore >= level ? Material.LIME_STAINED_GLASS_PANE : Material.RED_STAINED_GLASS_PANE;
-		return GUIUtils.createBasicItem(newMat, 1,
-			"Level " + level, theClass.mClassColor, true,
-			ability.getDescription(level).color(NamedTextColor.WHITE), 30, true);
-	}
-
 	public ItemStack createEnhanceItem(PlayerClass theClass, AbilityInfo<?> ability, Player player) {
 		if (ability.getDescriptions().size() == 3) {
 			Material newMat;
 			ItemStack newItem;
 			String scoreboard = ability.getScoreboard();
-			boolean selectedEn = false;
 			switch (scoreboard == null ? 0 : ScoreboardUtils.getScoreboardValue(player, scoreboard)) {
 				case 0 -> {
 					newMat = Material.BARRIER;
@@ -685,11 +664,9 @@ public class ClassSelectionCustomInventory extends CustomInventory {
 				}
 				case 1, 2 -> {
 					newMat = Material.ORANGE_STAINED_GLASS_PANE;
-					selectedEn = false;
 				}
 				case 3, 4 -> {
 					newMat = Material.YELLOW_STAINED_GLASS_PANE;
-					selectedEn = true;
 				}
 				default -> {
 					newMat = Material.BARRIER;
@@ -700,11 +677,7 @@ public class ClassSelectionCustomInventory extends CustomInventory {
 			newItem = GUIUtils.createBasicItem(newMat, 1,
 				"Enhancement", theClass.mClassColor, true,
 				ability.getDescription(3), 30, true);
-			if (selectedEn) {
-				GUIUtils.setGuiNbtTag(newItem, "texture", "skill_select_en_lit");
-			} else {
-				GUIUtils.setGuiNbtTag(newItem, "texture", "skill_select_en_unlit");
-			}
+				GUIUtils.setGuiNbtTag(newItem, "texture", (newMat == Material.YELLOW_STAINED_GLASS_PANE) ? "skill_select_en_lit" : "skill_select_en_unlit");
 			return newItem;
 		}
 
@@ -775,7 +748,7 @@ public class ClassSelectionCustomInventory extends CustomInventory {
 			mInventory.setItem(COMMON_REMAINING_SPEC_LOC, summaryItem);
 		}
 		int currentSkillCount = ScoreboardUtils.getScoreboardValue(player, AbilityUtils.REMAINING_SKILL);
-		ItemStack summaryItem = GUIUtils.createBasicItem(currentSkillCount == 0 ? Material.BARRIER : Material.ROOTED_DIRT, "Skill Points", NamedTextColor.WHITE, false,
+		ItemStack summaryItem = GUIUtils.createBasicItem(currentSkillCount == 0 ? Material.BARRIER : Material.GREEN_CONCRETE, "Skill Points", NamedTextColor.WHITE, false,
 			"You have " + currentSkillCount + " skill point" + (currentSkillCount == 1 ? "" : "s") + " remaining.", NamedTextColor.LIGHT_PURPLE);
 		GUIUtils.setGuiNbtTag(summaryItem, "texture", "cross_gui_total_sp" + (currentSkillCount == 0 ? "_none" : ""));
 		summaryItem.setAmount(currentSkillCount > 0 ? currentSkillCount : 1);

--- a/plugins/paper/src/main/java/com/playmonumenta/plugins/custominventories/ClassSelectionCustomInventory.java
+++ b/plugins/paper/src/main/java/com/playmonumenta/plugins/custominventories/ClassSelectionCustomInventory.java
@@ -316,6 +316,7 @@ public class ClassSelectionCustomInventory extends CustomInventory {
 		//back button
 		ItemStack backButton = GUIUtils.createBasicItem(Material.ARROW, "Back",
 			NamedTextColor.GRAY, false, "Return to the class selection page.", NamedTextColor.GRAY);
+		GUIUtils.setGuiNbtTag(backButton, "Gui", "skill_select_back");
 		mInventory.setItem(COMMON_BACK_LOC, backButton);
 
 		//possibly create reset spec item
@@ -323,6 +324,7 @@ public class ClassSelectionCustomInventory extends CustomInventory {
 		if (spec != 0) {
 			ItemStack specItem = GUIUtils.createBasicItem(Material.RED_BANNER, "Reset Your Specialization", NamedTextColor.WHITE, false,
 				"Click here to reset your specialization to select a new one.", NamedTextColor.LIGHT_PURPLE);
+			GUIUtils.setGuiNbtTag(specItem, "Gui", "cross_gui_reset_spec");
 			GUIUtils.setGuiNbtTag(specItem, "Spec",
 				(spec == userClass.mSpecOne.mSpecialization ? userClass.mSpecOne : userClass.mSpecTwo).mSpecName);
 			mInventory.setItem(SKILL_PAGE_RESET_SPEC_LOC, specItem);
@@ -364,12 +366,14 @@ public class ClassSelectionCustomInventory extends CustomInventory {
 		//back button
 		ItemStack backButton = GUIUtils.createBasicItem(Material.ARROW, "Back",
 			NamedTextColor.GRAY, false, "Return to the class selection page.", NamedTextColor.GRAY);
+		GUIUtils.setGuiNbtTag(backButton, "Gui", "skill_select_back");
 		mInventory.setItem(COMMON_BACK_LOC, backButton);
 
 		//possibly create reset spec item
 		if (ScoreboardUtils.getScoreboardValue(player, AbilityUtils.SCOREBOARD_SPEC_NAME) != 0) {
 			ItemStack specItem = GUIUtils.createBasicItem(Material.RED_BANNER, "Reset Your Specialization", NamedTextColor.WHITE, false,
 				"Click here to reset your specialization to select a new one.", NamedTextColor.LIGHT_PURPLE);
+			GUIUtils.setGuiNbtTag(specItem, "Gui", "cross_gui_reset_spec");
 			GUIUtils.setGuiNbtTag(specItem, "Spec",
 				(ScoreboardUtils.getScoreboardValue(player, AbilityUtils.SCOREBOARD_SPEC_NAME) == userClass.mSpecOne.mSpecialization ? userClass.mSpecOne : userClass.mSpecTwo).mSpecName);
 			mInventory.setItem(SKILL_PAGE_RESET_SPEC_LOC, specItem);
@@ -613,25 +617,40 @@ public class ClassSelectionCustomInventory extends CustomInventory {
 		if (ability.getDescriptions().size() == 3) {
 			Material newMat;
 			String scoreboard = ability.getScoreboard();
+			boolean selectedEn = false;
 			switch (scoreboard == null ? 0 : ScoreboardUtils.getScoreboardValue(player, scoreboard)) {
 				case 0 -> {
 					newMat = Material.BARRIER;
-					return GUIUtils.createBasicItem(newMat, 1,
+					ItemStack disabledEn = GUIUtils.createBasicItem(newMat, 1,
 						"Enhancement", theClass.mClassColor, true,
 						Component.text("Cannot Select; Choose levels in the ability first. Description: ").append(ability.getDescription(3)),
 						30, true);
+					GUIUtils.setGuiNbtTag(disabledEn, "Gui", "skill_select_en_disabled");
+					return disabledEn;
 				}
-				case 1, 2 -> newMat = Material.ORANGE_STAINED_GLASS_PANE;
-				case 3, 4 -> newMat = Material.YELLOW_STAINED_GLASS_PANE;
+				case 1, 2 -> {
+					newMat = Material.ORANGE_STAINED_GLASS_PANE;
+					selectedEn = false;
+				}
+				case 3, 4 -> {
+					newMat = Material.YELLOW_STAINED_GLASS_PANE;
+					selectedEn = true;
+				}
 				default -> {
 					newMat = Material.BARRIER;
 					return GUIUtils.createBasicItem(newMat, "Unknown Level",
 						theClass.mClassColor, true, "Unknown level for ability.", NamedTextColor.WHITE);
 				}
 			}
-			return GUIUtils.createBasicItem(newMat, 1,
+			newItem = GUIUtils.createBasicItem(newMat, 1,
 				"Enhancement", theClass.mClassColor, true,
 				ability.getDescription(3), 30, true);
+			if (selectedEn) {
+				GUIUtils.setGuiNbtTag(newItem, "Gui", "skill_select_en_lit");
+			} else {
+				GUIUtils.setGuiNbtTag(newItem, "Gui", "skill_select_en_unlit");
+			}
+			return newItem;
 		}
 
 		return GUIUtils.createBasicItem(Material.BARRIER, "No Option",

--- a/plugins/paper/src/main/java/com/playmonumenta/plugins/custominventories/ClassSelectionCustomInventory.java
+++ b/plugins/paper/src/main/java/com/playmonumenta/plugins/custominventories/ClassSelectionCustomInventory.java
@@ -49,8 +49,11 @@ public class ClassSelectionCustomInventory extends CustomInventory {
 	/**
 	 *  gui identifiers are used for rp to put a texture to a gui. they would be unique to each gui and work
 	 *  pretty much like a filler.
+	 *  After implementing sample rp, it is discovered that the theoretical max item size cannot reach our need,
+	 *  so in some guis, two identifiers may be added.
 	 */
-	private static final int GUI_IDENTIFIER_LOC = 45;
+	private static final int GUI_IDENTIFIER_LOC_L = 45; // bottom-left
+	private static final int GUI_IDENTIFIER_LOC_R = 53; // bottom-right
 
 	public static final ArrayList<Integer> P4_SPEC_LOCS = new ArrayList<>(Arrays.asList(20, 30, 40));
 	private static final MonumentaClasses mClasses = new MonumentaClasses();
@@ -285,7 +288,8 @@ public class ClassSelectionCustomInventory extends CustomInventory {
 		mInventory.setItem(P1_CHANGE_TRIGGERS_LOC, triggersItem);
 
 		// set gui identifier
-		mInventory.setItem(GUI_IDENTIFIER_LOC, GUIUtils.createGuiIdentifierItem("gui_class_1"));
+		mInventory.setItem(GUI_IDENTIFIER_LOC_L, GUIUtils.createGuiIdentifierItem("gui_class_1_l"));
+		mInventory.setItem(GUI_IDENTIFIER_LOC_R, GUIUtils.createGuiIdentifierItem("gui_class_1_r"));
 
 		makeRemainingCountItems(player);
 		fillEmptyAndSetPlainTags();
@@ -344,11 +348,17 @@ public class ClassSelectionCustomInventory extends CustomInventory {
 		}
 
 		// set gui identifier
-		ItemStack guiIdentifier = GUIUtils.createGuiIdentifierItem("gui_class_2_1");
+		ItemStack guiIdentifier = GUIUtils.createGuiIdentifierItem("gui_class_2_1_l");
 		GUIUtils.setGuiNbtTag(guiIdentifier, "class", userClass.mClassName);
 		GUIUtils.setGuiNbtTag(guiIdentifier, "spec",
 			(spec == 0) ? "none" : (spec == userClass.mSpecOne.mSpecialization ? userClass.mSpecOne : userClass.mSpecTwo).mSpecName);
-		mInventory.setItem(GUI_IDENTIFIER_LOC, guiIdentifier);
+		mInventory.setItem(GUI_IDENTIFIER_LOC_L, guiIdentifier);
+
+		guiIdentifier = GUIUtils.createGuiIdentifierItem("gui_class_2_1_r");
+		GUIUtils.setGuiNbtTag(guiIdentifier, "class", userClass.mClassName);
+		GUIUtils.setGuiNbtTag(guiIdentifier, "spec",
+			(spec == 0) ? "none" : (spec == userClass.mSpecOne.mSpecialization ? userClass.mSpecOne : userClass.mSpecTwo).mSpecName);
+		mInventory.setItem(GUI_IDENTIFIER_LOC_R, guiIdentifier);
 
 		makeRemainingCountItems(player);
 		fillEmptyAndSetPlainTags();
@@ -404,11 +414,17 @@ public class ClassSelectionCustomInventory extends CustomInventory {
 		}
 
 		// set gui identifier
-		ItemStack guiIdentifier = GUIUtils.createGuiIdentifierItem("gui_class_2_2");
+		ItemStack guiIdentifier = GUIUtils.createGuiIdentifierItem("gui_class_2_2_l");
 		GUIUtils.setGuiNbtTag(guiIdentifier, "class", userClass.mClassName);
 		GUIUtils.setGuiNbtTag(guiIdentifier, "spec",
 			(spec == 0) ? "none" : (spec == userClass.mSpecOne.mSpecialization ? userClass.mSpecOne : userClass.mSpecTwo).mSpecName);
-		mInventory.setItem(GUI_IDENTIFIER_LOC, guiIdentifier);
+		mInventory.setItem(GUI_IDENTIFIER_LOC_L, guiIdentifier);
+
+		guiIdentifier = GUIUtils.createGuiIdentifierItem("gui_class_2_2_r");
+		GUIUtils.setGuiNbtTag(guiIdentifier, "class", userClass.mClassName);
+		GUIUtils.setGuiNbtTag(guiIdentifier, "spec",
+			(spec == 0) ? "none" : (spec == userClass.mSpecOne.mSpecialization ? userClass.mSpecOne : userClass.mSpecTwo).mSpecName);
+		mInventory.setItem(GUI_IDENTIFIER_LOC_R, guiIdentifier);
 
 		makeRemainingCountItems(player);
 		fillEmptyAndSetPlainTags();
@@ -439,10 +455,15 @@ public class ClassSelectionCustomInventory extends CustomInventory {
 		mInventory.setItem(COMMON_BACK_LOC, backButton);
 
 		// set gui identifier
-		ItemStack guiIdentifier = GUIUtils.createGuiIdentifierItem("gui_class_3");
+		ItemStack guiIdentifier = GUIUtils.createGuiIdentifierItem("gui_class_3_l");
 		GUIUtils.setGuiNbtTag(guiIdentifier, "class", userClass.mClassName);
 		GUIUtils.setGuiNbtTag(guiIdentifier, "spec", spec.mSpecName);
-		mInventory.setItem(GUI_IDENTIFIER_LOC, guiIdentifier);
+		mInventory.setItem(GUI_IDENTIFIER_LOC_L, guiIdentifier);
+
+		guiIdentifier = GUIUtils.createGuiIdentifierItem("gui_class_3_r");
+		GUIUtils.setGuiNbtTag(guiIdentifier, "class", userClass.mClassName);
+		GUIUtils.setGuiNbtTag(guiIdentifier, "spec", spec.mSpecName);
+		mInventory.setItem(GUI_IDENTIFIER_LOC_R, guiIdentifier);
 
 		makeRemainingCountItems(player);
 		fillEmptyAndSetPlainTags();

--- a/plugins/paper/src/main/java/com/playmonumenta/plugins/custominventories/ClassSelectionCustomInventory.java
+++ b/plugins/paper/src/main/java/com/playmonumenta/plugins/custominventories/ClassSelectionCustomInventory.java
@@ -46,6 +46,15 @@ public class ClassSelectionCustomInventory extends CustomInventory {
 
 	private static final ArrayList<Integer> P3_ABILITY_LOCS = new ArrayList<>(Arrays.asList(9, 14, 18, 23, 27, 32, 36, 41));
 
+	/**
+	 *  gui identifiers are used for rp to put a texture to a gui. they would be unique to each gui and work
+	 *  pretty much like a filler.
+	 */
+	private static final int P1_GUI_IDENTIFIER_LOC = 45;
+	private static final int P2_GUI_IDENTIFIER_LOC = 45;
+	private static final int P3_GUI_IDENTIFIER_LOC = 45;
+	private static final int P4_GUI_IDENTIFIER_LOC = 45;
+
 	public static final ArrayList<Integer> P4_SPEC_LOCS = new ArrayList<>(Arrays.asList(20, 30, 40));
 	private static final MonumentaClasses mClasses = new MonumentaClasses();
 	public static final String R3_UNLOCK_SCOREBOARD = "R3Access";
@@ -278,6 +287,9 @@ public class ClassSelectionCustomInventory extends CustomInventory {
 		GUIUtils.setGuiNbtTag(triggersItem, "Gui", "class_select_trigger");
 		mInventory.setItem(P1_CHANGE_TRIGGERS_LOC, triggersItem);
 
+		// set gui identifier
+		mInventory.setItem(P1_GUI_IDENTIFIER_LOC, GUIUtils.createGuiIdentifierItem("gui_class_1"));
+
 		makeRemainingCountItems(player);
 		fillEmptyAndSetPlainTags();
 	}
@@ -334,6 +346,9 @@ public class ClassSelectionCustomInventory extends CustomInventory {
 			mInventory.setItem(SKILL_PAGE_RESET_SPEC_LOC, specItem);
 		}
 
+		// set gui identifier
+		mInventory.setItem(P1_GUI_IDENTIFIER_LOC, GUIUtils.createGuiIdentifierItem("gui_class_2"));
+
 		makeRemainingCountItems(player);
 		fillEmptyAndSetPlainTags();
 	}
@@ -386,6 +401,9 @@ public class ClassSelectionCustomInventory extends CustomInventory {
 			mInventory.setItem(SKILL_PAGE_RESET_SPEC_LOC, specItem);
 		}
 
+		// set gui identifier
+		mInventory.setItem(P1_GUI_IDENTIFIER_LOC, GUIUtils.createGuiIdentifierItem("gui_class_2"));
+
 		makeRemainingCountItems(player);
 		fillEmptyAndSetPlainTags();
 	}
@@ -413,6 +431,10 @@ public class ClassSelectionCustomInventory extends CustomInventory {
 			NamedTextColor.GRAY, false, "Return to the skill selection page.", NamedTextColor.GRAY);
 		GUIUtils.setGuiNbtTag(backButton, "Gui", "spec_select_back");
 		mInventory.setItem(COMMON_BACK_LOC, backButton);
+
+		// set gui identifier
+		mInventory.setItem(P1_GUI_IDENTIFIER_LOC, GUIUtils.createGuiIdentifierItem("gui_class_3"));
+
 		makeRemainingCountItems(player);
 		fillEmptyAndSetPlainTags();
 	}

--- a/plugins/paper/src/main/java/com/playmonumenta/plugins/custominventories/ClassSelectionCustomInventory.java
+++ b/plugins/paper/src/main/java/com/playmonumenta/plugins/custominventories/ClassSelectionCustomInventory.java
@@ -740,6 +740,7 @@ public class ClassSelectionCustomInventory extends CustomInventory {
 			int currentEnhanceCount = ScoreboardUtils.getScoreboardValue(player, AbilityUtils.REMAINING_ENHANCE);
 			ItemStack summaryItem = GUIUtils.createBasicItem(currentEnhanceCount == 0 ? Material.BARRIER : Material.ENCHANTING_TABLE, "Enhancement Points", NamedTextColor.WHITE, false,
 				"You have " + currentEnhanceCount + " enhancement point" + (currentEnhanceCount == 1 ? "" : "s") + " remaining.", NamedTextColor.LIGHT_PURPLE);
+			GUIUtils.setGuiNbtTag(summaryItem, "Gui", "cross_gui_total_en" + currentEnhanceCount == 0 ? "_none" : "");
 			summaryItem.setAmount(currentEnhanceCount > 0 ? currentEnhanceCount : 1);
 			mInventory.setItem(COMMON_REMAINING_ENHANCEMENTS_LOC, summaryItem);
 		}
@@ -747,12 +748,14 @@ public class ClassSelectionCustomInventory extends CustomInventory {
 			int currentSpecCount = ScoreboardUtils.getScoreboardValue(player, AbilityUtils.REMAINING_SPEC);
 			ItemStack summaryItem = GUIUtils.createBasicItem(currentSpecCount == 0 ? Material.BARRIER : Material.SAND, "Specialization Points", NamedTextColor.WHITE, false,
 				"You have " + currentSpecCount + " specialization point" + (currentSpecCount == 1 ? "" : "s") + " remaining.", NamedTextColor.LIGHT_PURPLE);
+			GUIUtils.setGuiNbtTag(summaryItem, "Gui", "cross_gui_total_spec" + currentSpecCount == 0 ? "_none" : "");
 			summaryItem.setAmount(currentSpecCount > 0 ? currentSpecCount : 1);
 			mInventory.setItem(COMMON_REMAINING_SPEC_LOC, summaryItem);
 		}
 		int currentSkillCount = ScoreboardUtils.getScoreboardValue(player, AbilityUtils.REMAINING_SKILL);
 		ItemStack summaryItem = GUIUtils.createBasicItem(currentSkillCount == 0 ? Material.BARRIER : Material.GRASS_BLOCK, "Skill Points", NamedTextColor.WHITE, false,
 			"You have " + currentSkillCount + " skill point" + (currentSkillCount == 1 ? "" : "s") + " remaining.", NamedTextColor.LIGHT_PURPLE);
+		GUIUtils.setGuiNbtTag(summaryItem, "Gui", "cross_gui_total_sp" + currentSkillCount == 0 ? "_none" : "");
 		summaryItem.setAmount(currentSkillCount > 0 ? currentSkillCount : 1);
 		mInventory.setItem(COMMON_REMAINING_SKILL_LOC, summaryItem);
 	}

--- a/plugins/paper/src/main/java/com/playmonumenta/plugins/custominventories/ClassSelectionCustomInventory.java
+++ b/plugins/paper/src/main/java/com/playmonumenta/plugins/custominventories/ClassSelectionCustomInventory.java
@@ -298,9 +298,13 @@ public class ClassSelectionCustomInventory extends CustomInventory {
 		for (AbilityInfo<?> ability : userClass.mAbilities) {
 			ItemStack item = createAbilityItem(userClass, ability);
 			mInventory.setItem(P2_ABILITY_LOCS.get(iterator), item);
-			ItemStack levelOne = createLevelItem(userClass, ability, 1, player);
+
+			// level one item
+			ItemStack levelOne = createSkillLevelItem(userClass, ability, 1, player);
 			mInventory.setItem(P2_ABILITY_LOCS.get(iterator) + 1, levelOne);
-			ItemStack levelTwo = createLevelItem(userClass, ability, 2, player);
+
+			// level two item
+			ItemStack levelTwo = createSkillLevelItem(userClass, ability, 2, player);
 			mInventory.setItem(P2_ABILITY_LOCS.get(iterator++) + 2, levelTwo);
 		}
 		//specs
@@ -342,12 +346,15 @@ public class ClassSelectionCustomInventory extends CustomInventory {
 		for (AbilityInfo<?> ability : userClass.mAbilities) {
 			ItemStack item = createAbilityItem(userClass, ability);
 			mInventory.setItem(P3_ABILITY_LOCS.get(iterator), item);
-			ItemStack levelOne = createLevelItem(userClass, ability, 1, player);
+
+			ItemStack levelOne = createSkillLevelItem(userClass, ability, 1, player);
 			GUIUtils.setGuiNbtTag(levelOne, "Skill", ability.getDisplayName());
 			mInventory.setItem(P3_ABILITY_LOCS.get(iterator) + 1, levelOne);
-			ItemStack levelTwo = createLevelItem(userClass, ability, 2, player);
+
+			ItemStack levelTwo = createSkillLevelItem(userClass, ability, 2, player);
 			GUIUtils.setGuiNbtTag(levelTwo, "Skill", ability.getDisplayName());
 			mInventory.setItem(P3_ABILITY_LOCS.get(iterator) + 2, levelTwo);
+
 			ItemStack enhanceItem = createEnhanceItem(userClass, ability, player);
 			GUIUtils.setGuiNbtTag(enhanceItem, "Skill", ability.getDisplayName());
 			mInventory.setItem(P3_ABILITY_LOCS.get(iterator++) + 3, enhanceItem);
@@ -596,6 +603,26 @@ public class ClassSelectionCustomInventory extends CustomInventory {
 		}
 	}
 
+	public ItemStack createSkillLevelItem(PlayerClass theClass, AbilityInfo<?> ability, int level, Player player) {
+		ItemStack levelItem;
+		int getScore;
+		String scoreboard = ability.getScoreboard();
+		if (scoreboard == null) {
+			getScore = 0;
+		} else {
+			getScore = ScoreboardUtils.getScoreboardValue(player, scoreboard);
+			if (getScore > 2) {
+				getScore -= 2;
+			}
+		}
+		Material newMat = getScore >= level ? Material.LIME_STAINED_GLASS_PANE : Material.RED_STAINED_GLASS_PANE;
+		levelItem = GUIUtils.createBasicItem(newMat, 1,
+			"Level " + level, theClass.mClassColor, true,
+			ability.getDescription(level).color(NamedTextColor.WHITE), 30, true);
+		GUIUtils.setGuiNbtTag(levelItem, "Gui", "skill_select_" + getScore >= level ? "sp_lit" : "sp_unlit");
+		return levelItem;
+	}
+
 	public ItemStack createLevelItem(PlayerClass theClass, AbilityInfo<?> ability, int level, Player player) {
 		int getScore;
 		String scoreboard = ability.getScoreboard();
@@ -616,6 +643,7 @@ public class ClassSelectionCustomInventory extends CustomInventory {
 	public ItemStack createEnhanceItem(PlayerClass theClass, AbilityInfo<?> ability, Player player) {
 		if (ability.getDescriptions().size() == 3) {
 			Material newMat;
+			ItemStack newItem;
 			String scoreboard = ability.getScoreboard();
 			boolean selectedEn = false;
 			switch (scoreboard == null ? 0 : ScoreboardUtils.getScoreboardValue(player, scoreboard)) {

--- a/plugins/paper/src/main/java/com/playmonumenta/plugins/custominventories/ClassSelectionCustomInventory.java
+++ b/plugins/paper/src/main/java/com/playmonumenta/plugins/custominventories/ClassSelectionCustomInventory.java
@@ -397,9 +397,9 @@ public class ClassSelectionCustomInventory extends CustomInventory {
 		for (AbilityInfo<?> ability : spec.mAbilities) {
 			ItemStack item = createAbilityItem(userClass, ability);
 			mInventory.setItem(P4_SPEC_LOCS.get(iterator), item);
-			ItemStack levelOne = createLevelItem(userClass, ability, 1, player);
+			ItemStack levelOne = createLevelItem(userClass, ability, 1, player, true);
 			mInventory.setItem(P4_SPEC_LOCS.get(iterator) + 1, levelOne);
-			ItemStack levelTwo = createLevelItem(userClass, ability, 2, player);
+			ItemStack levelTwo = createLevelItem(userClass, ability, 2, player, true);
 			mInventory.setItem(P4_SPEC_LOCS.get(iterator++) + 2, levelTwo);
 		}
 
@@ -411,6 +411,7 @@ public class ClassSelectionCustomInventory extends CustomInventory {
 		//back button
 		ItemStack backButton = GUIUtils.createBasicItem(Material.ARROW, "Back",
 			NamedTextColor.GRAY, false, "Return to the skill selection page.", NamedTextColor.GRAY);
+		GUIUtils.setGuiNbtTag(backButton, "Gui", "spec_select_back");
 		mInventory.setItem(COMMON_BACK_LOC, backButton);
 		makeRemainingCountItems(player);
 		fillEmptyAndSetPlainTags();

--- a/plugins/paper/src/main/java/com/playmonumenta/plugins/custominventories/ClassSelectionCustomInventory.java
+++ b/plugins/paper/src/main/java/com/playmonumenta/plugins/custominventories/ClassSelectionCustomInventory.java
@@ -40,7 +40,7 @@ public class ClassSelectionCustomInventory extends CustomInventory {
 	private static final int P1_RESET_CLASS_LOC = 47;
 	private static final int P1_RESET_SPEC_LOC = 49;
 	private static final int P1_CHANGE_TRIGGERS_LOC = 51;
-	public static final ArrayList<Integer> P2_ABILITY_LOCS = new ArrayList<>(Arrays.asList(10, 14, 19, 23, 28, 32, 37, 41));
+	public static final ArrayList<Integer> P2_ABILITY_LOCS = new ArrayList<>(Arrays.asList(9, 14, 18, 23, 27, 32, 36, 41));
 	public static final ArrayList<Integer> SKILL_PAGE_SPEC_LOCS = new ArrayList<>(Arrays.asList(47, 51));
 	private static final int SKILL_PAGE_RESET_SPEC_LOC = 49;
 
@@ -247,11 +247,13 @@ public class ClassSelectionCustomInventory extends CustomInventory {
 
 		ItemStack summaryItem = GUIUtils.createBasicItem(Material.SCUTE, "Main Menu", NamedTextColor.WHITE, false,
 			"Pick a class to view abilities within that class. You can reset your class at any time, with no consequences.", NamedTextColor.LIGHT_PURPLE);
+		GUIUtils.setGuiNbtTag(summaryItem, "Gui", "class_select_main_menu");
 		mInventory.setItem(COMMON_SUMMARY_LOC, summaryItem);
 
 		if (ScoreboardUtils.getScoreboardValue(player, AbilityUtils.SCOREBOARD_CLASS_NAME) != 0) {
 			ItemStack resetItem = GUIUtils.createBasicItem(Material.CYAN_BED, "Reset Your Class", NamedTextColor.WHITE, false,
 				"Click here to reset your class, allowing access to other choices.", NamedTextColor.LIGHT_PURPLE);
+			GUIUtils.setGuiNbtTag(resetItem, "Gui", "class_select_reset_class");
 			if (playerClass != null) {
 				GUIUtils.setGuiNbtTag(resetItem, "Class", playerClass.mClassName);
 			}
@@ -263,6 +265,7 @@ public class ClassSelectionCustomInventory extends CustomInventory {
 		if (spec != 0) {
 			ItemStack specItem = GUIUtils.createBasicItem(Material.RED_BANNER, "Reset Your Specialization", NamedTextColor.WHITE, false,
 				"Click here to reset your specialization, allowing access to choose either specialization.", NamedTextColor.LIGHT_PURPLE);
+			GUIUtils.setGuiNbtTag(specItem, "Gui", "cross_gui_reset_spec");
 			if (playerClass != null) {
 				GUIUtils.setGuiNbtTag(specItem, "Spec",
 					(spec == playerClass.mSpecOne.mSpecialization ? playerClass.mSpecOne : playerClass.mSpecTwo).mSpecName);
@@ -272,6 +275,7 @@ public class ClassSelectionCustomInventory extends CustomInventory {
 
 		ItemStack triggersItem = GUIUtils.createBasicItem(Material.JIGSAW, "Change Ability Triggers", NamedTextColor.WHITE, false,
 			"Click here to change which key combinations are used to cast abilities.", NamedTextColor.LIGHT_PURPLE);
+		GUIUtils.setGuiNbtTag(triggersItem, "Gui", "class_select_trigger");
 		mInventory.setItem(P1_CHANGE_TRIGGERS_LOC, triggersItem);
 
 		makeRemainingCountItems(player);

--- a/plugins/paper/src/main/java/com/playmonumenta/plugins/custominventories/ClassSelectionCustomInventory.java
+++ b/plugins/paper/src/main/java/com/playmonumenta/plugins/custominventories/ClassSelectionCustomInventory.java
@@ -657,7 +657,7 @@ public class ClassSelectionCustomInventory extends CustomInventory {
 			GUIUtils.setGuiNbtTag(levelItem, "texture", "skill_select_" + (getScore >= level ? "sp_lit" : "sp_unlit"));
 		}
 		GUIUtils.setGuiNbtTag(levelItem, "skill", ability.getDisplayName());
-		GUIUtils.setGuiNbtTag(levelItem, "level",  "" + level);
+		GUIUtils.setGuiNbtTag(levelItem, "level", "" + level);
 		return levelItem;
 	}
 

--- a/plugins/paper/src/main/java/com/playmonumenta/plugins/custominventories/ClassSelectionCustomInventory.java
+++ b/plugins/paper/src/main/java/com/playmonumenta/plugins/custominventories/ClassSelectionCustomInventory.java
@@ -256,13 +256,13 @@ public class ClassSelectionCustomInventory extends CustomInventory {
 
 		ItemStack summaryItem = GUIUtils.createBasicItem(Material.SCUTE, "Main Menu", NamedTextColor.WHITE, false,
 			"Pick a class to view abilities within that class. You can reset your class at any time, with no consequences.", NamedTextColor.LIGHT_PURPLE);
-		GUIUtils.setGuiNbtTag(summaryItem, "Gui", "class_select_main_menu");
+		GUIUtils.setGuiNbtTag(summaryItem, "texture", "class_select_main_menu");
 		mInventory.setItem(COMMON_SUMMARY_LOC, summaryItem);
 
 		if (ScoreboardUtils.getScoreboardValue(player, AbilityUtils.SCOREBOARD_CLASS_NAME) != 0) {
 			ItemStack resetItem = GUIUtils.createBasicItem(Material.CYAN_BED, "Reset Your Class", NamedTextColor.WHITE, false,
 				"Click here to reset your class, allowing access to other choices.", NamedTextColor.LIGHT_PURPLE);
-			GUIUtils.setGuiNbtTag(resetItem, "Gui", "class_select_reset_class");
+			GUIUtils.setGuiNbtTag(resetItem, "texture", "class_select_reset_class");
 			if (playerClass != null) {
 				GUIUtils.setGuiNbtTag(resetItem, "Class", playerClass.mClassName);
 			}
@@ -274,7 +274,7 @@ public class ClassSelectionCustomInventory extends CustomInventory {
 		if (spec != 0) {
 			ItemStack specItem = GUIUtils.createBasicItem(Material.RED_BANNER, "Reset Your Specialization", NamedTextColor.WHITE, false,
 				"Click here to reset your specialization, allowing access to choose either specialization.", NamedTextColor.LIGHT_PURPLE);
-			GUIUtils.setGuiNbtTag(specItem, "Gui", "cross_gui_reset_spec");
+			GUIUtils.setGuiNbtTag(specItem, "texture", "cross_gui_reset_spec");
 			if (playerClass != null) {
 				GUIUtils.setGuiNbtTag(specItem, "Spec",
 					(spec == playerClass.mSpecOne.mSpecialization ? playerClass.mSpecOne : playerClass.mSpecTwo).mSpecName);
@@ -284,7 +284,7 @@ public class ClassSelectionCustomInventory extends CustomInventory {
 
 		ItemStack triggersItem = GUIUtils.createBasicItem(Material.JIGSAW, "Change Ability Triggers", NamedTextColor.WHITE, false,
 			"Click here to change which key combinations are used to cast abilities.", NamedTextColor.LIGHT_PURPLE);
-		GUIUtils.setGuiNbtTag(triggersItem, "Gui", "class_select_trigger");
+		GUIUtils.setGuiNbtTag(triggersItem, "texture", "class_select_trigger");
 		mInventory.setItem(P1_CHANGE_TRIGGERS_LOC, triggersItem);
 
 		// set gui identifier
@@ -332,7 +332,7 @@ public class ClassSelectionCustomInventory extends CustomInventory {
 		//back button
 		ItemStack backButton = GUIUtils.createBasicItem(Material.ARROW, "Back",
 			NamedTextColor.GRAY, false, "Return to the class selection page.", NamedTextColor.GRAY);
-		GUIUtils.setGuiNbtTag(backButton, "Gui", "skill_select_back");
+		GUIUtils.setGuiNbtTag(backButton, "texture", "skill_select_back");
 		mInventory.setItem(COMMON_BACK_LOC, backButton);
 
 		//possibly create reset spec item
@@ -340,7 +340,7 @@ public class ClassSelectionCustomInventory extends CustomInventory {
 		if (spec != 0) {
 			ItemStack specItem = GUIUtils.createBasicItem(Material.RED_BANNER, "Reset Your Specialization", NamedTextColor.WHITE, false,
 				"Click here to reset your specialization to select a new one.", NamedTextColor.LIGHT_PURPLE);
-			GUIUtils.setGuiNbtTag(specItem, "Gui", "cross_gui_reset_spec");
+			GUIUtils.setGuiNbtTag(specItem, "texture", "cross_gui_reset_spec");
 			GUIUtils.setGuiNbtTag(specItem, "Spec",
 				(spec == userClass.mSpecOne.mSpecialization ? userClass.mSpecOne : userClass.mSpecTwo).mSpecName);
 			mInventory.setItem(SKILL_PAGE_RESET_SPEC_LOC, specItem);
@@ -388,14 +388,14 @@ public class ClassSelectionCustomInventory extends CustomInventory {
 		//back button
 		ItemStack backButton = GUIUtils.createBasicItem(Material.ARROW, "Back",
 			NamedTextColor.GRAY, false, "Return to the class selection page.", NamedTextColor.GRAY);
-		GUIUtils.setGuiNbtTag(backButton, "Gui", "skill_select_back");
+		GUIUtils.setGuiNbtTag(backButton, "texture", "skill_select_back");
 		mInventory.setItem(COMMON_BACK_LOC, backButton);
 
 		//possibly create reset spec item
 		if (ScoreboardUtils.getScoreboardValue(player, AbilityUtils.SCOREBOARD_SPEC_NAME) != 0) {
 			ItemStack specItem = GUIUtils.createBasicItem(Material.RED_BANNER, "Reset Your Specialization", NamedTextColor.WHITE, false,
 				"Click here to reset your specialization to select a new one.", NamedTextColor.LIGHT_PURPLE);
-			GUIUtils.setGuiNbtTag(specItem, "Gui", "cross_gui_reset_spec");
+			GUIUtils.setGuiNbtTag(specItem, "texture", "cross_gui_reset_spec");
 			GUIUtils.setGuiNbtTag(specItem, "Spec",
 				(ScoreboardUtils.getScoreboardValue(player, AbilityUtils.SCOREBOARD_SPEC_NAME) == userClass.mSpecOne.mSpecialization ? userClass.mSpecOne : userClass.mSpecTwo).mSpecName);
 			mInventory.setItem(SKILL_PAGE_RESET_SPEC_LOC, specItem);
@@ -429,7 +429,7 @@ public class ClassSelectionCustomInventory extends CustomInventory {
 		//back button
 		ItemStack backButton = GUIUtils.createBasicItem(Material.ARROW, "Back",
 			NamedTextColor.GRAY, false, "Return to the skill selection page.", NamedTextColor.GRAY);
-		GUIUtils.setGuiNbtTag(backButton, "Gui", "spec_select_back");
+		GUIUtils.setGuiNbtTag(backButton, "texture", "spec_select_back");
 		mInventory.setItem(COMMON_BACK_LOC, backButton);
 
 		// set gui identifier
@@ -643,9 +643,9 @@ public class ClassSelectionCustomInventory extends CustomInventory {
 			"Level " + level, theClass.mClassColor, true,
 			ability.getDescription(level).color(NamedTextColor.WHITE), 30, true);
 		if (isSpec) {
-			GUIUtils.setGuiNbtTag(levelItem, "Gui", "spec_select_" + (getScore >= level ? "spec_lit" : "spec_unlit"));
+			GUIUtils.setGuiNbtTag(levelItem, "texture", "spec_select_" + (getScore >= level ? "spec_lit" : "spec_unlit"));
 		} else {
-			GUIUtils.setGuiNbtTag(levelItem, "Gui", "skill_select_" + (getScore >= level ? "sp_lit" : "sp_unlit"));
+			GUIUtils.setGuiNbtTag(levelItem, "texture", "skill_select_" + (getScore >= level ? "sp_lit" : "sp_unlit"));
 		}
 		return levelItem;
 	}
@@ -680,7 +680,7 @@ public class ClassSelectionCustomInventory extends CustomInventory {
 						"Enhancement", theClass.mClassColor, true,
 						Component.text("Cannot Select; Choose levels in the ability first. Description: ").append(ability.getDescription(3)),
 						30, true);
-					GUIUtils.setGuiNbtTag(disabledEn, "Gui", "skill_select_en_disabled");
+					GUIUtils.setGuiNbtTag(disabledEn, "texture", "skill_select_en_disabled");
 					return disabledEn;
 				}
 				case 1, 2 -> {
@@ -701,9 +701,9 @@ public class ClassSelectionCustomInventory extends CustomInventory {
 				"Enhancement", theClass.mClassColor, true,
 				ability.getDescription(3), 30, true);
 			if (selectedEn) {
-				GUIUtils.setGuiNbtTag(newItem, "Gui", "skill_select_en_lit");
+				GUIUtils.setGuiNbtTag(newItem, "texture", "skill_select_en_lit");
 			} else {
-				GUIUtils.setGuiNbtTag(newItem, "Gui", "skill_select_en_unlit");
+				GUIUtils.setGuiNbtTag(newItem, "texture", "skill_select_en_unlit");
 			}
 			return newItem;
 		}
@@ -762,7 +762,7 @@ public class ClassSelectionCustomInventory extends CustomInventory {
 			int currentEnhanceCount = ScoreboardUtils.getScoreboardValue(player, AbilityUtils.REMAINING_ENHANCE);
 			ItemStack summaryItem = GUIUtils.createBasicItem(currentEnhanceCount == 0 ? Material.BARRIER : Material.ENCHANTING_TABLE, "Enhancement Points", NamedTextColor.WHITE, false,
 				"You have " + currentEnhanceCount + " enhancement point" + (currentEnhanceCount == 1 ? "" : "s") + " remaining.", NamedTextColor.LIGHT_PURPLE);
-			GUIUtils.setGuiNbtTag(summaryItem, "Gui", "cross_gui_total_en" + currentEnhanceCount == 0 ? "_none" : "");
+			GUIUtils.setGuiNbtTag(summaryItem, "texture", "cross_gui_total_en" + currentEnhanceCount == 0 ? "_none" : "");
 			summaryItem.setAmount(currentEnhanceCount > 0 ? currentEnhanceCount : 1);
 			mInventory.setItem(COMMON_REMAINING_ENHANCEMENTS_LOC, summaryItem);
 		}
@@ -770,14 +770,14 @@ public class ClassSelectionCustomInventory extends CustomInventory {
 			int currentSpecCount = ScoreboardUtils.getScoreboardValue(player, AbilityUtils.REMAINING_SPEC);
 			ItemStack summaryItem = GUIUtils.createBasicItem(currentSpecCount == 0 ? Material.BARRIER : Material.SAND, "Specialization Points", NamedTextColor.WHITE, false,
 				"You have " + currentSpecCount + " specialization point" + (currentSpecCount == 1 ? "" : "s") + " remaining.", NamedTextColor.LIGHT_PURPLE);
-			GUIUtils.setGuiNbtTag(summaryItem, "Gui", "cross_gui_total_spec" + currentSpecCount == 0 ? "_none" : "");
+			GUIUtils.setGuiNbtTag(summaryItem, "texture", "cross_gui_total_spec" + currentSpecCount == 0 ? "_none" : "");
 			summaryItem.setAmount(currentSpecCount > 0 ? currentSpecCount : 1);
 			mInventory.setItem(COMMON_REMAINING_SPEC_LOC, summaryItem);
 		}
 		int currentSkillCount = ScoreboardUtils.getScoreboardValue(player, AbilityUtils.REMAINING_SKILL);
 		ItemStack summaryItem = GUIUtils.createBasicItem(currentSkillCount == 0 ? Material.BARRIER : Material.GRASS_BLOCK, "Skill Points", NamedTextColor.WHITE, false,
 			"You have " + currentSkillCount + " skill point" + (currentSkillCount == 1 ? "" : "s") + " remaining.", NamedTextColor.LIGHT_PURPLE);
-		GUIUtils.setGuiNbtTag(summaryItem, "Gui", "cross_gui_total_sp" + currentSkillCount == 0 ? "_none" : "");
+		GUIUtils.setGuiNbtTag(summaryItem, "texture", "cross_gui_total_sp" + currentSkillCount == 0 ? "_none" : "");
 		summaryItem.setAmount(currentSkillCount > 0 ? currentSkillCount : 1);
 		mInventory.setItem(COMMON_REMAINING_SKILL_LOC, summaryItem);
 	}

--- a/plugins/paper/src/main/java/com/playmonumenta/plugins/custominventories/ClassSelectionCustomInventory.java
+++ b/plugins/paper/src/main/java/com/playmonumenta/plugins/custominventories/ClassSelectionCustomInventory.java
@@ -300,11 +300,11 @@ public class ClassSelectionCustomInventory extends CustomInventory {
 			mInventory.setItem(P2_ABILITY_LOCS.get(iterator), item);
 
 			// level one item
-			ItemStack levelOne = createSkillLevelItem(userClass, ability, 1, player);
+			ItemStack levelOne = createLevelItem(userClass, ability, 1, player, false);
 			mInventory.setItem(P2_ABILITY_LOCS.get(iterator) + 1, levelOne);
 
 			// level two item
-			ItemStack levelTwo = createSkillLevelItem(userClass, ability, 2, player);
+			ItemStack levelTwo = createLevelItem(userClass, ability, 2, player, false);
 			mInventory.setItem(P2_ABILITY_LOCS.get(iterator++) + 2, levelTwo);
 		}
 		//specs
@@ -347,11 +347,11 @@ public class ClassSelectionCustomInventory extends CustomInventory {
 			ItemStack item = createAbilityItem(userClass, ability);
 			mInventory.setItem(P3_ABILITY_LOCS.get(iterator), item);
 
-			ItemStack levelOne = createSkillLevelItem(userClass, ability, 1, player);
+			ItemStack levelOne = createLevelItem(userClass, ability, 1, player, false);
 			GUIUtils.setGuiNbtTag(levelOne, "Skill", ability.getDisplayName());
 			mInventory.setItem(P3_ABILITY_LOCS.get(iterator) + 1, levelOne);
 
-			ItemStack levelTwo = createSkillLevelItem(userClass, ability, 2, player);
+			ItemStack levelTwo = createLevelItem(userClass, ability, 2, player, false);
 			GUIUtils.setGuiNbtTag(levelTwo, "Skill", ability.getDisplayName());
 			mInventory.setItem(P3_ABILITY_LOCS.get(iterator) + 2, levelTwo);
 
@@ -603,7 +603,7 @@ public class ClassSelectionCustomInventory extends CustomInventory {
 		}
 	}
 
-	public ItemStack createSkillLevelItem(PlayerClass theClass, AbilityInfo<?> ability, int level, Player player) {
+	public ItemStack createLevelItem(PlayerClass theClass, AbilityInfo<?> ability, int level, Player player, boolean isSpec) {
 		ItemStack levelItem;
 		int getScore;
 		String scoreboard = ability.getScoreboard();
@@ -619,7 +619,11 @@ public class ClassSelectionCustomInventory extends CustomInventory {
 		levelItem = GUIUtils.createBasicItem(newMat, 1,
 			"Level " + level, theClass.mClassColor, true,
 			ability.getDescription(level).color(NamedTextColor.WHITE), 30, true);
-		GUIUtils.setGuiNbtTag(levelItem, "Gui", "skill_select_" + getScore >= level ? "sp_lit" : "sp_unlit");
+		if (isSpec) {
+			GUIUtils.setGuiNbtTag(levelItem, "Gui", "spec_select_" + (getScore >= level ? "spec_lit" : "spec_unlit"));
+		} else {
+			GUIUtils.setGuiNbtTag(levelItem, "Gui", "skill_select_" + (getScore >= level ? "sp_lit" : "sp_unlit"));
+		}
 		return levelItem;
 	}
 

--- a/plugins/paper/src/main/java/com/playmonumenta/plugins/custominventories/ClassSelectionCustomInventory.java
+++ b/plugins/paper/src/main/java/com/playmonumenta/plugins/custominventories/ClassSelectionCustomInventory.java
@@ -775,7 +775,7 @@ public class ClassSelectionCustomInventory extends CustomInventory {
 			mInventory.setItem(COMMON_REMAINING_SPEC_LOC, summaryItem);
 		}
 		int currentSkillCount = ScoreboardUtils.getScoreboardValue(player, AbilityUtils.REMAINING_SKILL);
-		ItemStack summaryItem = GUIUtils.createBasicItem(currentSkillCount == 0 ? Material.BARRIER : Material.GRASS_BLOCK, "Skill Points", NamedTextColor.WHITE, false,
+		ItemStack summaryItem = GUIUtils.createBasicItem(currentSkillCount == 0 ? Material.BARRIER : Material.ROOTED_DIRT, "Skill Points", NamedTextColor.WHITE, false,
 			"You have " + currentSkillCount + " skill point" + (currentSkillCount == 1 ? "" : "s") + " remaining.", NamedTextColor.LIGHT_PURPLE);
 		GUIUtils.setGuiNbtTag(summaryItem, "texture", "cross_gui_total_sp" + currentSkillCount == 0 ? "_none" : "");
 		summaryItem.setAmount(currentSkillCount > 0 ? currentSkillCount : 1);

--- a/plugins/paper/src/main/java/com/playmonumenta/plugins/guis/AbilityTriggersGui.java
+++ b/plugins/paper/src/main/java/com/playmonumenta/plugins/guis/AbilityTriggersGui.java
@@ -30,6 +30,8 @@ import org.jetbrains.annotations.Nullable;
 public class AbilityTriggersGui extends Gui {
 
 	private static final Component MAIN_PAGE_TITLE = Component.text("Ability Triggers");
+	private static final int GUI_IDENTIFIER_LOC_L = 45;
+	private static final int GUI_IDENTIFIER_LOC_R = 53;
 	private @Nullable AbilityInfo<?> mSelectedAbility;
 	private @Nullable AbilityTriggerInfo<?> mSelectedTrigger;
 	private @Nullable AbilityTrigger mNewTrigger;
@@ -112,9 +114,11 @@ public class AbilityTriggersGui extends Gui {
 
 			// gui identifier - filler with tag for rp gui support (bottom left corner)
 			if (mPreviousGUI) {
-				setItem(8, GUIUtils.createGuiIdentifierItem("gui_class_4"));
+				setItem(GUI_IDENTIFIER_LOC_L, GUIUtils.createGuiIdentifierItem("gui_class_4_l"));
+				setItem(GUI_IDENTIFIER_LOC_R, GUIUtils.createGuiIdentifierItem("gui_class_4_r"));
 			} else {
-				setItem(8, GUIUtils.createGuiIdentifierItem("gui_depth_4"));
+				setItem(GUI_IDENTIFIER_LOC_L, GUIUtils.createGuiIdentifierItem("gui_depth_4_l"));
+				setItem(GUI_IDENTIFIER_LOC_R, GUIUtils.createGuiIdentifierItem("gui_depth_4_r"));
 			}
 
 
@@ -312,7 +316,8 @@ public class AbilityTriggersGui extends Gui {
 			}
 
 			// gui identifier - filler with tag for rp gui support (bottom left)
-			setItem(8, GUIUtils.createGuiIdentifierItem("gui_class_5"));
+			setItem(GUI_IDENTIFIER_LOC_L, GUIUtils.createGuiIdentifierItem("gui_class_5_l"));
+			setItem(GUI_IDENTIFIER_LOC_R, GUIUtils.createGuiIdentifierItem("gui_class_5_r"));
 
 			// accept/cancel buttons
 			if (!mNewTrigger.equals(mSelectedTrigger.getTrigger())) {

--- a/plugins/paper/src/main/java/com/playmonumenta/plugins/guis/AbilityTriggersGui.java
+++ b/plugins/paper/src/main/java/com/playmonumenta/plugins/guis/AbilityTriggersGui.java
@@ -257,8 +257,10 @@ public class AbilityTriggersGui extends Gui {
 			for (int col = colStart; col <= colEnd; col++) {
 				AbilityTrigger.KeyOptions keyOption = AbilityTrigger.KeyOptions.values()[mKeyOptionsStartIndex + col - colStart];
 				boolean enabled = mNewTrigger.getKeyOptions().contains(keyOption);
-				makeOptionIcons(3, col, GUIUtils.createBasicItem(keyOption.getMaterial(), capitalize(keyOption.getDisplay(enabled)), enabled ? NamedTextColor.RED : NamedTextColor.GRAY, false,
-						"Click to toggle", NamedTextColor.GRAY, 40), enabled ? Material.RED_STAINED_GLASS_PANE : Material.GRAY_STAINED_GLASS_PANE, () -> {
+				tempItem = GUIUtils.createBasicItem(keyOption.getMaterial(), capitalize(keyOption.getDisplay(enabled)), enabled ? NamedTextColor.RED : NamedTextColor.GRAY, false,
+					"Click to toggle", NamedTextColor.GRAY, 40);
+				GUIUtils.setGuiNbtTag(tempItem, "Gui", "trigger_detail_" + keyOption.getGuiTag(enabled));
+				makeOptionIcons(3, col, tempItem, enabled ? Material.RED_STAINED_GLASS_PANE : Material.GRAY_STAINED_GLASS_PANE, () -> {
 					EnumSet<AbilityTrigger.KeyOptions> keyOptions = mNewTrigger.getKeyOptions();
 					if (!keyOptions.remove(keyOption)) {
 						keyOptions.add(keyOption);
@@ -338,6 +340,7 @@ public class AbilityTriggersGui extends Gui {
 		setItem(row, column, display).onLeftClick(onClick);
 		ItemStack indicator = display.clone();
 		indicator.setType(indicatorMaterial);
+		GUIUtils.setGuiNbtTag(indicator, "Gui", "trigger_detail_empty");
 		setItem(row + 1, column, indicator).onLeftClick(onClick);
 	}
 

--- a/plugins/paper/src/main/java/com/playmonumenta/plugins/guis/AbilityTriggersGui.java
+++ b/plugins/paper/src/main/java/com/playmonumenta/plugins/guis/AbilityTriggersGui.java
@@ -218,6 +218,7 @@ public class AbilityTriggersGui extends Gui {
 				case "Looking level or up" -> "up_mid";
 				case "Looking down or up" -> "up_down";
 				case "Looking down or level" -> "mid_down";
+				default -> "unsupported";
 			});
 			tempItem = GUIUtils.createBasicItem(Material.HEART_OF_THE_SEA, looking, NamedTextColor.GRAY, false,
 				"Click to cycle through look directions", NamedTextColor.GRAY, 40);
@@ -392,7 +393,8 @@ public class AbilityTriggersGui extends Gui {
 			case "sneaking" -> "sneak";
 			case "sprinting" -> "sprint";
 			case "on ground" -> "ground";
-		}
+			default -> "unsupported";
+		};
 		guiTag = "trigger_detail_" + guiTag + (value == AbilityTrigger.BinaryOption.TRUE ?  "_true"
 			: value == AbilityTrigger.BinaryOption.FALSE ? "_false"
 			: "_both");

--- a/plugins/paper/src/main/java/com/playmonumenta/plugins/guis/AbilityTriggersGui.java
+++ b/plugins/paper/src/main/java/com/playmonumenta/plugins/guis/AbilityTriggersGui.java
@@ -174,11 +174,13 @@ public class AbilityTriggersGui extends Gui {
 			});
 			tempItem = GUIUtils.createBasicItem(Material.JIGSAW, "Key: " + mNewTrigger.getKey(), NamedTextColor.WHITE, false,
 				"Click to cycle through main key.\nNote that this also changes the \"extras\" when changed.", NamedTextColor.GRAY, 40);
+
 			GUIUtils.setGuiNbtTag(tempItem, "texture", "trigger_detail_" + (switch (mNewTrigger.getKey()) {
 				case LEFT_CLICK -> "left";
 				case RIGHT_CLICK -> "right";
 				case SWAP -> "swap";
 				case DROP -> "drop";
+				default -> "";
 			}));
 			makeOptionIcons(1, 1, tempItem, switch (mNewTrigger.getKey()) {
 				case LEFT_CLICK -> Material.IRON_SWORD;
@@ -395,8 +397,8 @@ public class AbilityTriggersGui extends Gui {
 			case "on ground" -> "ground";
 			default -> "unsupported";
 		};
-		guiTag = "trigger_detail_" + guiTag + (value == AbilityTrigger.BinaryOption.TRUE ?  "_true"
-			: value == AbilityTrigger.BinaryOption.FALSE ? "_false"
+		guiTag = "trigger_detail_" + guiTag + ((value == AbilityTrigger.BinaryOption.TRUE) ?  "_true"
+			: (value == AbilityTrigger.BinaryOption.FALSE) ? "_false"
 			: "_both");
 		ItemStack tempItem = GUIUtils.createBasicItem(material, displayName, color, false,
 			"Click to cycle through options", NamedTextColor.GRAY, 40);

--- a/plugins/paper/src/main/java/com/playmonumenta/plugins/guis/AbilityTriggersGui.java
+++ b/plugins/paper/src/main/java/com/playmonumenta/plugins/guis/AbilityTriggersGui.java
@@ -110,6 +110,9 @@ public class AbilityTriggersGui extends Gui {
 				}
 			}
 
+			// gui identifier - filler with tag for rp gui support (bottom left corner)
+			setItem(8, GUIUtils.createGuiIdentifierItem("gui_class_4"));
+
 			// "revert all" button - top right to hopefully prevent accidental presses
 			int numberOfCustomTriggers = mPlugin.mAbilityManager.getNumberOfCustomTriggers(mPlayer);
 			if (numberOfCustomTriggers > 0) {
@@ -299,6 +302,9 @@ public class AbilityTriggersGui extends Gui {
 					update();
 				});
 			}
+
+			// gui identifier - filler with tag for rp gui support (bottom left)
+			setItem(8, GUIUtils.createGuiIdentifierItem("gui_class_5"));
 
 			// accept/cancel buttons
 			if (!mNewTrigger.equals(mSelectedTrigger.getTrigger())) {

--- a/plugins/paper/src/main/java/com/playmonumenta/plugins/guis/AbilityTriggersGui.java
+++ b/plugins/paper/src/main/java/com/playmonumenta/plugins/guis/AbilityTriggersGui.java
@@ -156,13 +156,22 @@ public class AbilityTriggersGui extends Gui {
 				summary, true));
 
 			// options
-			makeOptionIcons(1, 0, GUIUtils.createBasicItem(Material.BARRIER, mNewTrigger.isEnabled() ? "Trigger enabled" : "Trigger disabled", mNewTrigger.isEnabled() ? NamedTextColor.GREEN : NamedTextColor.RED, false,
-					"Click to " + (mNewTrigger.isEnabled() ? "disable" : "enable") + " the trigger", NamedTextColor.GRAY, 40), mNewTrigger.isEnabled() ? Material.GREEN_STAINED_GLASS_PANE : Material.RED_STAINED_GLASS_PANE, () -> {
+			tempItem = GUIUtils.createBasicItem(Material.BARRIER, mNewTrigger.isEnabled() ? "Trigger enabled" : "Trigger disabled", mNewTrigger.isEnabled() ? NamedTextColor.GREEN : NamedTextColor.RED, false,
+				"Click to " + (mNewTrigger.isEnabled() ? "disable" : "enable") + " the trigger", NamedTextColor.GRAY, 40);
+			GUIUtils.setGuiNbtTag(tempItem, "Gui", "trigger_detail_" + (mNewTrigger.isEnabled() ? "enabled" : "disabled"));
+			makeOptionIcons(1, 0, tempItem, mNewTrigger.isEnabled() ? Material.GREEN_STAINED_GLASS_PANE : Material.RED_STAINED_GLASS_PANE, () -> {
 				mNewTrigger.setEnabled(!mNewTrigger.isEnabled());
 				update();
 			});
-			makeOptionIcons(1, 1, GUIUtils.createBasicItem(Material.JIGSAW, "Key: " + mNewTrigger.getKey(), NamedTextColor.WHITE, false,
-					"Click to cycle through main key.\nNote that this also changes the \"extras\" when changed.", NamedTextColor.GRAY, 40), switch (mNewTrigger.getKey()) {
+			tempItem = GUIUtils.createBasicItem(Material.JIGSAW, "Key: " + mNewTrigger.getKey(), NamedTextColor.WHITE, false,
+				"Click to cycle through main key.\nNote that this also changes the \"extras\" when changed.", NamedTextColor.GRAY, 40);
+			GUIUtils.setGuiNbtTag(tempItem, "Gui", "trigger_detail_" + (switch (mNewTrigger.getKey()) {
+				case LEFT_CLICK -> "left";
+				case RIGHT_CLICK -> "right";
+				case SWAP -> "swap";
+				case DROP -> "drop";
+			}));
+			makeOptionIcons(1, 1, tempItem, switch (mNewTrigger.getKey()) {
 				case LEFT_CLICK -> Material.IRON_SWORD;
 				case RIGHT_CLICK -> Material.BOW;
 				case SWAP -> Material.TORCH;

--- a/plugins/paper/src/main/java/com/playmonumenta/plugins/guis/AbilityTriggersGui.java
+++ b/plugins/paper/src/main/java/com/playmonumenta/plugins/guis/AbilityTriggersGui.java
@@ -46,6 +46,7 @@ public class AbilityTriggersGui extends Gui {
 	@SuppressWarnings("unused")
 	protected void setup() {
 		ItemStack tempItem;
+		String guiTag;
 		if (mSelectedAbility == null) {
 			// back icon
 			if (mPreviousGUI) {
@@ -188,8 +189,10 @@ public class AbilityTriggersGui extends Gui {
 				}
 				update();
 			});
-			makeOptionIcons(1, 3, GUIUtils.createBasicItem(Material.SHEARS, "Double click: " + (mNewTrigger.isDoubleClick() ? "yes" : "no"), mNewTrigger.isDoubleClick() ? NamedTextColor.GREEN : NamedTextColor.GRAY, false,
-					"Click to toggle requiring a double click", NamedTextColor.GRAY, 40), mNewTrigger.isDoubleClick() ? Material.GREEN_STAINED_GLASS_PANE : Material.GRAY_STAINED_GLASS_PANE, () -> {
+			tempItem = GUIUtils.createBasicItem(Material.SHEARS, "Double click: " + (mNewTrigger.isDoubleClick() ? "yes" : "no"), mNewTrigger.isDoubleClick() ? NamedTextColor.GREEN : NamedTextColor.GRAY, false,
+				"Click to toggle requiring a double click", NamedTextColor.GRAY, 40);
+			GUIUtils.setGuiNbtTag(tempItem, "Gui", "trigger_detail_dclick_" + (mNewTrigger.isDoubleClick() ? "true" : "false"));
+			makeOptionIcons(1, 3, tempItem, mNewTrigger.isDoubleClick() ? Material.GREEN_STAINED_GLASS_PANE : Material.GRAY_STAINED_GLASS_PANE, () -> {
 				mNewTrigger.setDoubleClick(!mNewTrigger.isDoubleClick());
 				update();
 			});
@@ -199,8 +202,19 @@ public class AbilityTriggersGui extends Gui {
 
 			String looking = "Looking " + (mNewTrigger.getLookDirections().size() == 3 ? "anywhere"
 					: mNewTrigger.getLookDirections().stream().map(d -> d.name().toLowerCase(Locale.ROOT)).collect(Collectors.joining(" or ")));
-			makeOptionIcons(1, 7, GUIUtils.createBasicItem(Material.HEART_OF_THE_SEA, looking, NamedTextColor.GRAY, false,
-					"Click to cycle through look directions", NamedTextColor.GRAY, 40), mNewTrigger.getLookDirections().size() == 3 ? Material.GRAY_STAINED_GLASS_PANE : Material.RED_STAINED_GLASS_PANE, () -> {
+			guiTag = "trigger_detail_look_" + (switch (looking) {
+				case "Looking anywhere" -> "all";
+				case "Looking up" -> "up";
+				case "Looking level" -> "mid";
+				case "Looking down" -> "down";
+				case "Looking level or up" -> "up_mid";
+				case "Looking down or up" -> "up_down";
+				case "Looking down or level" -> "mid_down";
+			});
+			tempItem = GUIUtils.createBasicItem(Material.HEART_OF_THE_SEA, looking, NamedTextColor.GRAY, false,
+				"Click to cycle through look directions", NamedTextColor.GRAY, 40);
+			GUIUtils.setGuiNbtTag(tempItem, "Gui", guiTag);
+			makeOptionIcons(1, 7, tempItem, mNewTrigger.getLookDirections().size() == 3 ? Material.GRAY_STAINED_GLASS_PANE : Material.RED_STAINED_GLASS_PANE, () -> {
 				EnumSet<AbilityTrigger.LookDirection> lookDirections = mNewTrigger.getLookDirections();
 				AbilityTrigger.LookDirection[] values = AbilityTrigger.LookDirection.values();
 				if (lookDirections.size() == 3) {
@@ -226,8 +240,10 @@ public class AbilityTriggersGui extends Gui {
 				update();
 			});
 
-			makeOptionIcons(1, 8, GUIUtils.createBasicItem(Material.POINTED_DRIPSTONE, "Allow fall-through: " + (mNewTrigger.isFallThrough() ? "yes" : "no"), mNewTrigger.isFallThrough() ? NamedTextColor.GREEN : NamedTextColor.GRAY, false,
-				"Click to toggle whether another ability with an overlapping trigger will be triggered if this ability fails or is on cooldown.", NamedTextColor.GRAY, 40), mNewTrigger.isFallThrough() ? Material.GREEN_STAINED_GLASS_PANE : Material.GRAY_STAINED_GLASS_PANE, () -> {
+			tempItem = GUIUtils.createBasicItem(Material.POINTED_DRIPSTONE, "Allow fall-through: " + (mNewTrigger.isFallThrough() ? "yes" : "no"), mNewTrigger.isFallThrough() ? NamedTextColor.GREEN : NamedTextColor.GRAY, false,
+				"Click to toggle whether another ability with an overlapping trigger will be triggered if this ability fails or is on cooldown.", NamedTextColor.GRAY, 40);
+			GUIUtils.setGuiNbtTag(tempItem, "Gui", "trigger_detail_fall_through_" + (mNewTrigger.isFallThrough() ? "true" : "false"));
+			makeOptionIcons(1, 8, tempItem, mNewTrigger.isFallThrough() ? Material.GREEN_STAINED_GLASS_PANE : Material.GRAY_STAINED_GLASS_PANE, () -> {
 				mNewTrigger.setFallThrough(!mNewTrigger.isFallThrough());
 				update();
 			});
@@ -360,8 +376,20 @@ public class AbilityTriggersGui extends Gui {
 		NamedTextColor color = value == AbilityTrigger.BinaryOption.TRUE ? NamedTextColor.GREEN
 				: value == AbilityTrigger.BinaryOption.FALSE ? NamedTextColor.RED
 				: NamedTextColor.GRAY;
-		makeOptionIcons(row, column, GUIUtils.createBasicItem(material, displayName, color, false,
-				"Click to cycle through options", NamedTextColor.GRAY, 40), value, () -> {
+
+		String guiTag = switch (name) {
+			case "sneaking" -> "sneak";
+			case "sprinting" -> "sprint";
+			case "on ground" -> "ground";
+		}
+		guiTag = "trigger_detail_" + guiTag + (value == AbilityTrigger.BinaryOption.TRUE ?  "_true"
+			: value == AbilityTrigger.BinaryOption.FALSE ? "_false"
+			: "_both");
+		ItemStack tempItem = GUIUtils.createBasicItem(material, displayName, color, false,
+			"Click to cycle through options", NamedTextColor.GRAY, 40);
+		GUIUtils.setGuiNbtTag(tempItem, "Gui", guiTag);
+
+		makeOptionIcons(row, column, tempItem, value, () -> {
 			setter.accept(AbilityTrigger.BinaryOption.values()[(value.ordinal() + 1) % AbilityTrigger.BinaryOption.values().length]);
 			update();
 		});

--- a/plugins/paper/src/main/java/com/playmonumenta/plugins/guis/AbilityTriggersGui.java
+++ b/plugins/paper/src/main/java/com/playmonumenta/plugins/guis/AbilityTriggersGui.java
@@ -52,13 +52,13 @@ public class AbilityTriggersGui extends Gui {
 			if (mPreviousGUI) {
 				tempItem = GUIUtils.createBasicItem(Material.ARROW, "Back", NamedTextColor.GRAY, false,
 					"Return to the class selection page.", NamedTextColor.GRAY, 40);
-				GUIUtils.setGuiNbtTag(tempItem, "Gui", "trigger_main_back");
+				GUIUtils.setGuiNbtTag(tempItem, "texture", "trigger_main_back");
 				setItem(0, tempItem)
 					.onLeftClick(() -> new ClassSelectionCustomInventory(mPlayer).openInventory(mPlayer, mPlugin));
 			} else {
 				tempItem = GUIUtils.createBasicItem(Material.ARROW, "Back", NamedTextColor.GRAY, false,
 					"Return to the ability summary page.", NamedTextColor.GRAY, 40);
-				GUIUtils.setGuiNbtTag(tempItem, "Gui", "depth_trigger_main_back");
+				GUIUtils.setGuiNbtTag(tempItem, "texture", "depth_trigger_main_back");
 				setItem(0, tempItem)
 					.onLeftClick(() -> new DepthsSummaryGUI(mPlayer).openInventory(mPlayer, mPlugin));
 			}
@@ -70,7 +70,7 @@ public class AbilityTriggersGui extends Gui {
 					"If not, the next trigger is checked, and so forth until a trigger matches and casts its ability.\n" +
 					"Eagle Eye is an exception: it allows other abilities to trigger after it.\n" +
 					"Right-click a trigger to immediately perform the trigger's action (e.g. toggle some state).", NamedTextColor.GRAY, 40);
-			GUIUtils.setGuiNbtTag(tempItem, "Gui", "depth_main_help");
+			GUIUtils.setGuiNbtTag(tempItem, "texture", "depth_main_help");
 			setItem(4, tempItem);
 
 			// trigger icons
@@ -117,7 +117,7 @@ public class AbilityTriggersGui extends Gui {
 					Component.text("This resets all triggers of all abilities of all classes back to defaults!\nYou currently have ", NamedTextColor.RED)
 						.append(Component.text(numberOfCustomTriggers, NamedTextColor.GOLD))
 						.append(Component.text(" custom trigger" + (numberOfCustomTriggers == 1 ? "" : "s") + " defined.", NamedTextColor.RED)), 40, true);
-				GUIUtils.setGuiNbtTag(tempItem, "Gui", "depth_main_reset_trigger");
+				GUIUtils.setGuiNbtTag(tempItem, "texture", "depth_main_reset_trigger");
 				setItem(8, tempItem)
 					.onLeftClick(() -> {
 						mPlugin.mAbilityManager.clearCustomTriggers(mPlayer);
@@ -133,7 +133,7 @@ public class AbilityTriggersGui extends Gui {
 			// back icon
 			tempItem = GUIUtils.createBasicItem(Material.ARROW, "Back",
 				NamedTextColor.GRAY, false, "Return to the trigger selection page.", NamedTextColor.GRAY, 40);
-			GUIUtils.setGuiNbtTag(tempItem, "Gui", "trigger_detail_back");
+			GUIUtils.setGuiNbtTag(tempItem, "texture", "trigger_detail_back");
 			setItem(0, 0, tempItem)
 					.onLeftClick(() -> {
 						mSelectedAbility = null;
@@ -159,14 +159,14 @@ public class AbilityTriggersGui extends Gui {
 			// options
 			tempItem = GUIUtils.createBasicItem(Material.BARRIER, mNewTrigger.isEnabled() ? "Trigger enabled" : "Trigger disabled", mNewTrigger.isEnabled() ? NamedTextColor.GREEN : NamedTextColor.RED, false,
 				"Click to " + (mNewTrigger.isEnabled() ? "disable" : "enable") + " the trigger", NamedTextColor.GRAY, 40);
-			GUIUtils.setGuiNbtTag(tempItem, "Gui", "trigger_detail_" + (mNewTrigger.isEnabled() ? "enabled" : "disabled"));
+			GUIUtils.setGuiNbtTag(tempItem, "texture", "trigger_detail_" + (mNewTrigger.isEnabled() ? "enabled" : "disabled"));
 			makeOptionIcons(1, 0, tempItem, mNewTrigger.isEnabled() ? Material.GREEN_STAINED_GLASS_PANE : Material.RED_STAINED_GLASS_PANE, () -> {
 				mNewTrigger.setEnabled(!mNewTrigger.isEnabled());
 				update();
 			});
 			tempItem = GUIUtils.createBasicItem(Material.JIGSAW, "Key: " + mNewTrigger.getKey(), NamedTextColor.WHITE, false,
 				"Click to cycle through main key.\nNote that this also changes the \"extras\" when changed.", NamedTextColor.GRAY, 40);
-			GUIUtils.setGuiNbtTag(tempItem, "Gui", "trigger_detail_" + (switch (mNewTrigger.getKey()) {
+			GUIUtils.setGuiNbtTag(tempItem, "texture", "trigger_detail_" + (switch (mNewTrigger.getKey()) {
 				case LEFT_CLICK -> "left";
 				case RIGHT_CLICK -> "right";
 				case SWAP -> "swap";
@@ -191,7 +191,7 @@ public class AbilityTriggersGui extends Gui {
 			});
 			tempItem = GUIUtils.createBasicItem(Material.SHEARS, "Double click: " + (mNewTrigger.isDoubleClick() ? "yes" : "no"), mNewTrigger.isDoubleClick() ? NamedTextColor.GREEN : NamedTextColor.GRAY, false,
 				"Click to toggle requiring a double click", NamedTextColor.GRAY, 40);
-			GUIUtils.setGuiNbtTag(tempItem, "Gui", "trigger_detail_dclick_" + (mNewTrigger.isDoubleClick() ? "true" : "false"));
+			GUIUtils.setGuiNbtTag(tempItem, "texture", "trigger_detail_dclick_" + (mNewTrigger.isDoubleClick() ? "true" : "false"));
 			makeOptionIcons(1, 3, tempItem, mNewTrigger.isDoubleClick() ? Material.GREEN_STAINED_GLASS_PANE : Material.GRAY_STAINED_GLASS_PANE, () -> {
 				mNewTrigger.setDoubleClick(!mNewTrigger.isDoubleClick());
 				update();
@@ -213,7 +213,7 @@ public class AbilityTriggersGui extends Gui {
 			});
 			tempItem = GUIUtils.createBasicItem(Material.HEART_OF_THE_SEA, looking, NamedTextColor.GRAY, false,
 				"Click to cycle through look directions", NamedTextColor.GRAY, 40);
-			GUIUtils.setGuiNbtTag(tempItem, "Gui", guiTag);
+			GUIUtils.setGuiNbtTag(tempItem, "texture", guiTag);
 			makeOptionIcons(1, 7, tempItem, mNewTrigger.getLookDirections().size() == 3 ? Material.GRAY_STAINED_GLASS_PANE : Material.RED_STAINED_GLASS_PANE, () -> {
 				EnumSet<AbilityTrigger.LookDirection> lookDirections = mNewTrigger.getLookDirections();
 				AbilityTrigger.LookDirection[] values = AbilityTrigger.LookDirection.values();
@@ -242,7 +242,7 @@ public class AbilityTriggersGui extends Gui {
 
 			tempItem = GUIUtils.createBasicItem(Material.POINTED_DRIPSTONE, "Allow fall-through: " + (mNewTrigger.isFallThrough() ? "yes" : "no"), mNewTrigger.isFallThrough() ? NamedTextColor.GREEN : NamedTextColor.GRAY, false,
 				"Click to toggle whether another ability with an overlapping trigger will be triggered if this ability fails or is on cooldown.", NamedTextColor.GRAY, 40);
-			GUIUtils.setGuiNbtTag(tempItem, "Gui", "trigger_detail_fall_through_" + (mNewTrigger.isFallThrough() ? "true" : "false"));
+			GUIUtils.setGuiNbtTag(tempItem, "texture", "trigger_detail_fall_through_" + (mNewTrigger.isFallThrough() ? "true" : "false"));
 			makeOptionIcons(1, 8, tempItem, mNewTrigger.isFallThrough() ? Material.GREEN_STAINED_GLASS_PANE : Material.GRAY_STAINED_GLASS_PANE, () -> {
 				mNewTrigger.setFallThrough(!mNewTrigger.isFallThrough());
 				update();
@@ -252,7 +252,7 @@ public class AbilityTriggersGui extends Gui {
 			tempItem = GUIUtils.createBasicItem(Material.CHAIN_COMMAND_BLOCK, "Extras", NamedTextColor.WHITE, false,
 				"Extra options for held items.\n"
 					+ "When the main key is changed these are set to defaults, unless the trigger has an unchangeable item restriction.", NamedTextColor.GRAY, 40);
-			GUIUtils.setGuiNbtTag(tempItem, "Gui", "trigger_detail_extras");
+			GUIUtils.setGuiNbtTag(tempItem, "texture", "trigger_detail_extras");
 			setItem(3, 0, tempItem);
 
 			int colStart = 1;
@@ -263,7 +263,7 @@ public class AbilityTriggersGui extends Gui {
 			} else if (mKeyOptionsStartIndex > 1) {
 				colStart = 2;
 				tempItem = GUIUtils.createBasicItem(Material.ARROW, "Scroll back for more options", NamedTextColor.GRAY);
-				GUIUtils.setGuiNbtTag(tempItem, "Gui", "trigger_detail_scroll_back");
+				GUIUtils.setGuiNbtTag(tempItem, "texture", "trigger_detail_scroll_back");
 				setItem(3, 1, tempItem).onLeftClick(() -> {
 					mKeyOptionsStartIndex -= 6;
 					update();
@@ -272,7 +272,7 @@ public class AbilityTriggersGui extends Gui {
 			if (mKeyOptionsStartIndex + 7 < AbilityTrigger.KeyOptions.values().length) {
 				colEnd = 7;
 				tempItem = GUIUtils.createBasicItem(Material.ARROW, "Scroll forward for more options", NamedTextColor.GRAY);
-				GUIUtils.setGuiNbtTag(tempItem, "Gui", "trigger_detail_scroll_forward");
+				GUIUtils.setGuiNbtTag(tempItem, "texture", "trigger_detail_scroll_forward");
 				setItem(3, 8, tempItem).onLeftClick(() -> {
 					mKeyOptionsStartIndex += mKeyOptionsStartIndex == 0 ? 7 : 6;
 					update();
@@ -284,7 +284,7 @@ public class AbilityTriggersGui extends Gui {
 				boolean enabled = mNewTrigger.getKeyOptions().contains(keyOption);
 				tempItem = GUIUtils.createBasicItem(keyOption.getMaterial(), capitalize(keyOption.getDisplay(enabled)), enabled ? NamedTextColor.RED : NamedTextColor.GRAY, false,
 					"Click to toggle", NamedTextColor.GRAY, 40);
-				GUIUtils.setGuiNbtTag(tempItem, "Gui", "trigger_detail_" + keyOption.getGuiTag(enabled));
+				GUIUtils.setGuiNbtTag(tempItem, "texture", "trigger_detail_" + keyOption.getGuiTag(enabled));
 				makeOptionIcons(3, col, tempItem, enabled ? Material.RED_STAINED_GLASS_PANE : Material.GRAY_STAINED_GLASS_PANE, () -> {
 					EnumSet<AbilityTrigger.KeyOptions> keyOptions = mNewTrigger.getKeyOptions();
 					if (!keyOptions.remove(keyOption)) {
@@ -309,7 +309,7 @@ public class AbilityTriggersGui extends Gui {
 					meta.lore(List.of(Component.text("Accept trigger changes", NamedTextColor.GRAY).decoration(TextDecoration.ITALIC, false)));
 					confirm.setItemMeta(meta);
 					ItemUtils.setPlainTag(confirm);
-					GUIUtils.setGuiNbtTag(confirm, "Gui", "trigger_detail_confirm");
+					GUIUtils.setGuiNbtTag(confirm, "texture", "trigger_detail_confirm");
 					setItem(5, 2, confirm).onLeftClick(() -> {
 						mSelectedTrigger.setTrigger(mNewTrigger);
 						mPlugin.mAbilityManager.setCustomTrigger(mPlayer, mSelectedAbility, mSelectedTrigger.getId(), mNewTrigger);
@@ -326,7 +326,7 @@ public class AbilityTriggersGui extends Gui {
 					meta.lore(List.of(Component.text("Discard current trigger changes", NamedTextColor.GRAY).decoration(TextDecoration.ITALIC, false)));
 					cancel.setItemMeta(meta);
 					ItemUtils.setPlainTag(cancel);
-					GUIUtils.setGuiNbtTag(cancel, "Gui", "trigger_detail_cancel");
+					GUIUtils.setGuiNbtTag(cancel, "texture", "trigger_detail_cancel");
 					setItem(5, 6, cancel).onLeftClick(() -> {
 						mNewTrigger = new AbilityTrigger(mSelectedTrigger.getTrigger());
 						mSelectedAbility = null;
@@ -339,7 +339,7 @@ public class AbilityTriggersGui extends Gui {
 			// revert button
 			tempItem = GUIUtils.createBasicItem(Material.BARRIER, "Revert to default", NamedTextColor.DARK_RED, false,
 				"Revert any custom trigger changes", NamedTextColor.GRAY, 40);
-			GUIUtils.setGuiNbtTag(tempItem, "Gui", "trigger_detail_revert");
+			GUIUtils.setGuiNbtTag(tempItem, "texture", "trigger_detail_revert");
 			if (!mSelectedTrigger.getTrigger().equals(mSelectedAbility.getTrigger(mSelectedTrigger.getId()).getTrigger())) {
 				setItem(5, 4, tempItem).onLeftClick(() -> {
 					mNewTrigger = new AbilityTrigger(mSelectedAbility.getTrigger(mSelectedTrigger.getId()).getTrigger());
@@ -365,7 +365,7 @@ public class AbilityTriggersGui extends Gui {
 		setItem(row, column, display).onLeftClick(onClick);
 		ItemStack indicator = display.clone();
 		indicator.setType(indicatorMaterial);
-		GUIUtils.setGuiNbtTag(indicator, "Gui", "trigger_detail_empty");
+		GUIUtils.setGuiNbtTag(indicator, "texture", "trigger_detail_empty");
 		setItem(row + 1, column, indicator).onLeftClick(onClick);
 	}
 
@@ -387,7 +387,7 @@ public class AbilityTriggersGui extends Gui {
 			: "_both");
 		ItemStack tempItem = GUIUtils.createBasicItem(material, displayName, color, false,
 			"Click to cycle through options", NamedTextColor.GRAY, 40);
-		GUIUtils.setGuiNbtTag(tempItem, "Gui", guiTag);
+		GUIUtils.setGuiNbtTag(tempItem, "texture", guiTag);
 
 		makeOptionIcons(row, column, tempItem, value, () -> {
 			setter.accept(AbilityTrigger.BinaryOption.values()[(value.ordinal() + 1) % AbilityTrigger.BinaryOption.values().length]);

--- a/plugins/paper/src/main/java/com/playmonumenta/plugins/guis/AbilityTriggersGui.java
+++ b/plugins/paper/src/main/java/com/playmonumenta/plugins/guis/AbilityTriggersGui.java
@@ -45,25 +45,32 @@ public class AbilityTriggersGui extends Gui {
 	@Override
 	@SuppressWarnings("unused")
 	protected void setup() {
+		ItemStack tempItem;
 		if (mSelectedAbility == null) {
 			// back icon
 			if (mPreviousGUI) {
-				setItem(0, GUIUtils.createBasicItem(Material.ARROW, "Back", NamedTextColor.GRAY, false,
-					"Return to the class selection page.", NamedTextColor.GRAY, 40))
+				tempItem = GUIUtils.createBasicItem(Material.ARROW, "Back", NamedTextColor.GRAY, false,
+					"Return to the class selection page.", NamedTextColor.GRAY, 40);
+				GUIUtils.setGuiNbtTag(tempItem, "Gui", "trigger_main_back");
+				setItem(0, tempItem)
 					.onLeftClick(() -> new ClassSelectionCustomInventory(mPlayer).openInventory(mPlayer, mPlugin));
 			} else {
-				setItem(0, GUIUtils.createBasicItem(Material.ARROW, "Back", NamedTextColor.GRAY, false,
-					"Return to the ability summary page.", NamedTextColor.GRAY, 40))
+				tempItem = GUIUtils.createBasicItem(Material.ARROW, "Back", NamedTextColor.GRAY, false,
+					"Return to the ability summary page.", NamedTextColor.GRAY, 40);
+				GUIUtils.setGuiNbtTag(tempItem, "Gui", "depth_trigger_main_back");
+				setItem(0, tempItem)
 					.onLeftClick(() -> new DepthsSummaryGUI(mPlayer).openInventory(mPlayer, mPlugin));
 			}
 
 			// help icon
-			setItem(4, GUIUtils.createBasicItem(Material.OAK_SIGN, "Help", NamedTextColor.WHITE, false,
+			tempItem = GUIUtils.createBasicItem(Material.OAK_SIGN, "Help", NamedTextColor.WHITE, false,
 				"Click on a trigger to change it.\n" +
 					"Triggers are shown in the order they are handled. Whenever a key is pressed, the top-left trigger is checked first if it matches. " +
 					"If not, the next trigger is checked, and so forth until a trigger matches and casts its ability.\n" +
 					"Eagle Eye is an exception: it allows other abilities to trigger after it.\n" +
-					"Right-click a trigger to immediately perform the trigger's action (e.g. toggle some state).", NamedTextColor.GRAY, 40));
+					"Right-click a trigger to immediately perform the trigger's action (e.g. toggle some state).", NamedTextColor.GRAY, 40);
+			GUIUtils.setGuiNbtTag(tempItem, "Gui", "depth_main_help");
+			setItem(4, tempItem);
 
 			// trigger icons
 			int i = 0;
@@ -105,10 +112,12 @@ public class AbilityTriggersGui extends Gui {
 			// "revert all" button - top right to hopefully prevent accidental presses
 			int numberOfCustomTriggers = mPlugin.mAbilityManager.getNumberOfCustomTriggers(mPlayer);
 			if (numberOfCustomTriggers > 0) {
-				setItem(8, GUIUtils.createBasicItem(Material.BARRIER, 1, "Revert all triggers to defaults", NamedTextColor.DARK_RED, false,
+				tempItem = GUIUtils.createBasicItem(Material.BARRIER, 1, "Revert all triggers to defaults", NamedTextColor.DARK_RED, false,
 					Component.text("This resets all triggers of all abilities of all classes back to defaults!\nYou currently have ", NamedTextColor.RED)
 						.append(Component.text(numberOfCustomTriggers, NamedTextColor.GOLD))
-						.append(Component.text(" custom trigger" + (numberOfCustomTriggers == 1 ? "" : "s") + " defined.", NamedTextColor.RED)), 40, true))
+						.append(Component.text(" custom trigger" + (numberOfCustomTriggers == 1 ? "" : "s") + " defined.", NamedTextColor.RED)), 40, true);
+				GUIUtils.setGuiNbtTag(tempItem, "Gui", "depth_main_reset_trigger");
+				setItem(8, tempItem)
 					.onLeftClick(() -> {
 						mPlugin.mAbilityManager.clearCustomTriggers(mPlayer);
 						for (Ability ability : mPlugin.mAbilityManager.getPlayerAbilities(mPlayer).getAbilitiesInTriggerOrder()) {
@@ -121,8 +130,10 @@ public class AbilityTriggersGui extends Gui {
 			}
 		} else {
 			// back icon
-			setItem(0, 0, GUIUtils.createBasicItem(Material.ARROW, "Back",
-					NamedTextColor.GRAY, false, "Return to the trigger selection page.", NamedTextColor.GRAY, 40))
+			tempItem = GUIUtils.createBasicItem(Material.ARROW, "Back",
+				NamedTextColor.GRAY, false, "Return to the trigger selection page.", NamedTextColor.GRAY, 40);
+			GUIUtils.setGuiNbtTag(tempItem, "Gui", "trigger_detail_back");
+			setItem(0, 0, tempItem)
 					.onLeftClick(() -> {
 						mSelectedAbility = null;
 						mKeyOptionsStartIndex = 0;
@@ -213,9 +224,11 @@ public class AbilityTriggersGui extends Gui {
 			});
 
 			// extras aka key options
-			setItem(3, 0, GUIUtils.createBasicItem(Material.CHAIN_COMMAND_BLOCK, "Extras", NamedTextColor.WHITE, false,
-					"Extra options for held items.\n"
-							+ "When the main key is changed these are set to defaults, unless the trigger has an unchangeable item restriction.", NamedTextColor.GRAY, 40));
+			tempItem = GUIUtils.createBasicItem(Material.CHAIN_COMMAND_BLOCK, "Extras", NamedTextColor.WHITE, false,
+				"Extra options for held items.\n"
+					+ "When the main key is changed these are set to defaults, unless the trigger has an unchangeable item restriction.", NamedTextColor.GRAY, 40);
+			GUIUtils.setGuiNbtTag(tempItem, "Gui", "trigger_detail_extras");
+			setItem(3, 0, tempItem);
 
 			int colStart = 1;
 			int colEnd = 8;
@@ -224,14 +237,18 @@ public class AbilityTriggersGui extends Gui {
 				mKeyOptionsStartIndex = 0;
 			} else if (mKeyOptionsStartIndex > 1) {
 				colStart = 2;
-				setItem(3, 1, GUIUtils.createBasicItem(Material.ARROW, "Scroll back for more options", NamedTextColor.GRAY)).onLeftClick(() -> {
+				tempItem = GUIUtils.createBasicItem(Material.ARROW, "Scroll back for more options", NamedTextColor.GRAY);
+				GUIUtils.setGuiNbtTag(tempItem, "Gui", "trigger_detail_scroll_back");
+				setItem(3, 1, tempItem).onLeftClick(() -> {
 					mKeyOptionsStartIndex -= 6;
 					update();
 				});
 			}
 			if (mKeyOptionsStartIndex + 7 < AbilityTrigger.KeyOptions.values().length) {
 				colEnd = 7;
-				setItem(3, 8, GUIUtils.createBasicItem(Material.ARROW, "Scroll forward for more options", NamedTextColor.GRAY)).onLeftClick(() -> {
+				tempItem = GUIUtils.createBasicItem(Material.ARROW, "Scroll forward for more options", NamedTextColor.GRAY);
+				GUIUtils.setGuiNbtTag(tempItem, "Gui", "trigger_detail_scroll_forward");
+				setItem(3, 8, tempItem).onLeftClick(() -> {
 					mKeyOptionsStartIndex += mKeyOptionsStartIndex == 0 ? 7 : 6;
 					update();
 				});
@@ -265,6 +282,7 @@ public class AbilityTriggersGui extends Gui {
 					meta.lore(List.of(Component.text("Accept trigger changes", NamedTextColor.GRAY).decoration(TextDecoration.ITALIC, false)));
 					confirm.setItemMeta(meta);
 					ItemUtils.setPlainTag(confirm);
+					GUIUtils.setGuiNbtTag(confirm, "Gui", "trigger_detail_confirm");
 					setItem(5, 2, confirm).onLeftClick(() -> {
 						mSelectedTrigger.setTrigger(mNewTrigger);
 						mPlugin.mAbilityManager.setCustomTrigger(mPlayer, mSelectedAbility, mSelectedTrigger.getId(), mNewTrigger);
@@ -281,6 +299,7 @@ public class AbilityTriggersGui extends Gui {
 					meta.lore(List.of(Component.text("Discard current trigger changes", NamedTextColor.GRAY).decoration(TextDecoration.ITALIC, false)));
 					cancel.setItemMeta(meta);
 					ItemUtils.setPlainTag(cancel);
+					GUIUtils.setGuiNbtTag(cancel, "Gui", "trigger_detail_cancel");
 					setItem(5, 6, cancel).onLeftClick(() -> {
 						mNewTrigger = new AbilityTrigger(mSelectedTrigger.getTrigger());
 						mSelectedAbility = null;
@@ -291,9 +310,11 @@ public class AbilityTriggersGui extends Gui {
 			}
 
 			// revert button
+			tempItem = GUIUtils.createBasicItem(Material.BARRIER, "Revert to default", NamedTextColor.DARK_RED, false,
+				"Revert any custom trigger changes", NamedTextColor.GRAY, 40);
+			GUIUtils.setGuiNbtTag(tempItem, "Gui", "trigger_detail_revert");
 			if (!mSelectedTrigger.getTrigger().equals(mSelectedAbility.getTrigger(mSelectedTrigger.getId()).getTrigger())) {
-				setItem(5, 4, GUIUtils.createBasicItem(Material.BARRIER, "Revert to default", NamedTextColor.DARK_RED, false,
-						"Revert any custom trigger changes", NamedTextColor.GRAY, 40)).onLeftClick(() -> {
+				setItem(5, 4, tempItem).onLeftClick(() -> {
 					mNewTrigger = new AbilityTrigger(mSelectedAbility.getTrigger(mSelectedTrigger.getId()).getTrigger());
 					mSelectedTrigger.setTrigger(mNewTrigger);
 					mPlugin.mAbilityManager.setCustomTrigger(mPlayer, mSelectedAbility, mSelectedTrigger.getId(), null);

--- a/plugins/paper/src/main/java/com/playmonumenta/plugins/guis/AbilityTriggersGui.java
+++ b/plugins/paper/src/main/java/com/playmonumenta/plugins/guis/AbilityTriggersGui.java
@@ -111,7 +111,12 @@ public class AbilityTriggersGui extends Gui {
 			}
 
 			// gui identifier - filler with tag for rp gui support (bottom left corner)
-			setItem(8, GUIUtils.createGuiIdentifierItem("gui_class_4"));
+			if (mPreviousGUI) {
+				setItem(8, GUIUtils.createGuiIdentifierItem("gui_class_4"));
+			} else {
+				setItem(8, GUIUtils.createGuiIdentifierItem("gui_depth_4"));
+			}
+
 
 			// "revert all" button - top right to hopefully prevent accidental presses
 			int numberOfCustomTriggers = mPlugin.mAbilityManager.getNumberOfCustomTriggers(mPlayer);

--- a/plugins/paper/src/main/java/com/playmonumenta/plugins/guis/AbilityTriggersGui.java
+++ b/plugins/paper/src/main/java/com/playmonumenta/plugins/guis/AbilityTriggersGui.java
@@ -201,7 +201,7 @@ public class AbilityTriggersGui extends Gui {
 			});
 			makeBinaryOptionIcon(1, 4, Material.FEATHER, "sneaking", mNewTrigger.getSneaking(), mNewTrigger::setSneaking);
 			makeBinaryOptionIcon(1, 5, Material.LEATHER_BOOTS, "sprinting", mNewTrigger.getSprinting(), mNewTrigger::setSprinting);
-			makeBinaryOptionIcon(1, 6, Material.GRASS_BLOCK, "on ground", mNewTrigger.getOnGround(), mNewTrigger::setOnGround);
+			makeBinaryOptionIcon(1, 6, Material.ROOTED_DIRT, "on ground", mNewTrigger.getOnGround(), mNewTrigger::setOnGround);
 
 			String looking = "Looking " + (mNewTrigger.getLookDirections().size() == 3 ? "anywhere"
 					: mNewTrigger.getLookDirections().stream().map(d -> d.name().toLowerCase(Locale.ROOT)).collect(Collectors.joining(" or ")));

--- a/plugins/paper/src/main/java/com/playmonumenta/plugins/utils/GUIUtils.java
+++ b/plugins/paper/src/main/java/com/playmonumenta/plugins/utils/GUIUtils.java
@@ -313,6 +313,15 @@ public class GUIUtils {
 		});
 	}
 
+	/**
+	 * Creates a gui identifier item. This is for the rp to apply gui texture. Other than that it works like a filler.
+	 */
+	public static ItemStack createGuiIdentifierItem(String tag) {
+		ItemStack idItem = createFiller();
+		setGuiNbtTag(idItem, "Gui", tag);
+		return idItem;
+	}
+
 	public static boolean isPlaceholder(final @Nullable ItemStack item) {
 		if (ItemUtils.isNullOrAir(item)) {
 			return false;

--- a/plugins/paper/src/main/java/com/playmonumenta/plugins/utils/GUIUtils.java
+++ b/plugins/paper/src/main/java/com/playmonumenta/plugins/utils/GUIUtils.java
@@ -318,7 +318,7 @@ public class GUIUtils {
 	 */
 	public static ItemStack createGuiIdentifierItem(String tag) {
 		ItemStack idItem = createFiller();
-		setGuiNbtTag(idItem, "Gui", tag);
+		setGuiNbtTag(idItem, "texture", tag);
 		return idItem;
 	}
 


### PR DESCRIPTION
RP support tags for class selection page!
I did some syntax debugging to ensure there are at least no syntax error, but didn't manage to compile onto sdk to test. If there are any changes, I'm all ears.

### class selection page
- added gui identifier
- added tag for `summaryItem`
- added tag for `resetItem`
- added tag for `triggersItem`
- added tag for `specItem` (reset spec)

### skill selection page
- added gui identifier
- shifted the locations of pre-enhancement menu left one to match the texture.
- added tag for `backButton` for both p2 and p3
- added tag for `specItem` (reset spec)
- added tag for enhancement point slot by updating `createEnhanceItem`
- added tags for the level items in skill selection pages
  - this creates an overload of `createLevelItem` method with an additional parameter specifying if the skill is a spec skill
- added tags for the items that shows how many unassigned skill points you gave

### spec skill selection page
- added gui identifier
- added tags for the level items
- added tags for the items that shows how many unassigned skill points you gave

### trigger page (choose trigger to tweak)
- added gui identifier
- added tag for back button
- added tag for help sign
- added tag for reset trigger button

### trigger detail page (tweak certain skill trigger)
- added gui identifier
- added tag for back button
- added tag for "extras" indicator
- added tag for the scroll forward/back button
- added tag for confirm/cancel button
- added tag for the revert button
- added tag for the enabled/disabled toggle button
- added tags for double click, sneaking, sprinting, on ground, looking, fall through buttons
- added tag for the activate key button
- added tags for all the keyOptions.

### cross gui items
- change the base item of remaining skill point indicator from grass_block to rooted_dirt
- change the base item of on ground option from grass_block to rooted_dirt

### API changes
- added a function in `GUIUtils.createGuiIdentifierItem` that creates a filler with a gui tag.
- added a new field in `AbilityTrigger.KeyOptions`: `mGuiTag` for rp tag
  - added an overload to `KeyOptions` constructor to support new tag
  - added a method `getGuiTag` to retrieve the tag