### PR TITLE
Implement suggestion 12507: hide blank side of copied sign

### DIFF
--- a/plugins/paper/src/main/java/com/playmonumenta/plugins/overrides/SignOverride.java
+++ b/plugins/paper/src/main/java/com/playmonumenta/plugins/overrides/SignOverride.java
@@ -219,6 +219,7 @@ public class SignOverride extends BaseOverride {
 						for (Side side : Side.values()) {
 							SignSide signSideBlock = sign.getSide(side);
 							SignSide signSideItem = signItem.getSide(side);
+							List<Component> tempLoreLines = new ArrayList<>();
 
 							DyeColor dyeColor = signSideBlock.getColor();
 
@@ -236,21 +237,30 @@ public class SignOverride extends BaseOverride {
 							));
 
 							List<Component> signLines = signSideBlock.lines();
+							boolean sideHasText = false;
 							for (int lineNum = 0; lineNum < signLines.size(); ++lineNum) {
 								Component line = signLines.get(lineNum);
 								chatFilterLines.add(line);
 								signSideItem.line(lineNum, line);
 								Component loreLine = loreHeader.append(loreBase.append(line));
-								loreLines.add(loreLine);
+								tempLoreLines.add(loreLine);
+								if(!MessagingUtils.plainText(line).isBlank()) {
+									sideHasText = true;
+								}
 							}
 
 							boolean sideGlowing = signSideBlock.isGlowingText();
 							signSideItem.setGlowingText(sideGlowing);
 							if (sideGlowing) {
-								loreLines.add(Component.text(SIGN_IS_GLOWING, NamedTextColor.WHITE));
+								tempLoreLines.add(Component.text(SIGN_IS_GLOWING, NamedTextColor.WHITE));
 							}
 
-							loreLines.add(Component.text(COPIED_SIGN_DIVIDER, NamedTextColor.GOLD));
+							tempLoreLines.add(Component.text(COPIED_SIGN_DIVIDER, NamedTextColor.GOLD));
+
+							if(side != Side.BACK || sideHasText) {
+								// back of sign shouldn't show in lore if there's no text on it
+								loreLines.addAll(tempLoreLines);
+							}
 						}
 						// Remove last divider
 						loreLines.remove(loreLines.size() - 1);


### PR DESCRIPTION
Suggestion 12507: "When copying a sign, only add lore to the item for each side with text on it. Removing the extra four blank lines and divider would let signs that are used as storage and shop labels take up less screen space, match older labels, and look a little nicer."