### PR TITLE
Fix bug 21998: armory treats ex/normal Emblem of Greed the same

### DIFF
--- a/plugins/paper/src/main/java/com/playmonumenta/plugins/managers/LoadoutManager.java
+++ b/plugins/paper/src/main/java/com/playmonumenta/plugins/managers/LoadoutManager.java
@@ -110,7 +110,7 @@ public class LoadoutManager implements Listener {
 	private static final ImmutableSet<Location> EXALTED_LOCATIONS = ImmutableSet.of(
 		// Region 1
 		Location.LABS, Location.WHITE, Location.ORANGE, Location.MAGENTA,
-		Location.LIGHTBLUE, Location.YELLOW, Location.REVERIE,
+		Location.LIGHTBLUE, Location.YELLOW, Location.REVERIE, Location.OVERWORLD1,
 		Location.WILLOWS, Location.WILLOWSKIN, Location.EPHEMERAL, Location.EPHEMERAL_ENHANCEMENTS,
 		Location.SANCTUM, Location.VERDANT, Location.VERDANTSKIN,
 		Location.AZACOR, Location.KAUL, Location.DIVINE, Location.ROYAL,


### PR DESCRIPTION
Bug link: https://discord.com/channels/313066655494438922/569283558741508107/1364014839755833446
"Armory cannot distinguish R1 Emblem of Greed from its exalted counterpart; whichever one happens to be first in equipment cases is taken. This occurs because Location.OVERWORLD1 is not in EXALTED_LOCATIONS in https://github.com/TeamMonumenta/monumenta-plugins-public/blob/master/plugins/paper/src/main/java/com/playmonumenta/plugins/managers/LoadoutManager.java#L110."