### PR TITLE
Ammunition Selection Implementation for Quiver

### DIFF
--- a/plugins/paper/src/main/java/com/playmonumenta/plugins/itemstats/enums/InfusionType.java
+++ b/plugins/paper/src/main/java/com/playmonumenta/plugins/itemstats/enums/InfusionType.java
@@ -59,6 +59,7 @@ public enum InfusionType {
 	VENGEFUL(new Vengeful(), "", true, false, false, false, true, true, true, false),
 
 	// Other Added Tags
+	AMMUNITION(new Ammunition(), "", false, false, false, false, false, false, false, false),
 	LOCKED(new Locked(), "", false, false, false, false, false, false, false, false),
 	ENLIGHTENING(new Enlightening(), "", false, false, false, false, true, false, false, false),
 	BARKING(new Barking(), "", true, false, true, false, false, false, false, false),

--- a/plugins/paper/src/main/java/com/playmonumenta/plugins/itemstats/infusions/Ammunition.java
+++ b/plugins/paper/src/main/java/com/playmonumenta/plugins/itemstats/infusions/Ammunition.java
@@ -1,0 +1,17 @@
+package com.playmonumenta.plugins.itemstats.infusions;
+
+import com.playmonumenta.plugins.itemstats.Infusion;
+import com.playmonumenta.plugins.itemstats.enums.InfusionType;
+
+public class Ammunition implements Infusion {
+
+	@Override
+	public String getName() {
+		return "Ammunition";
+	}
+
+	@Override
+	public InfusionType getInfusionType() {
+		return InfusionType.AMMUNITION;
+	}
+}

--- a/plugins/paper/src/main/java/com/playmonumenta/plugins/itemupdater/ItemUpdateHelper.java
+++ b/plugins/paper/src/main/java/com/playmonumenta/plugins/itemupdater/ItemUpdateHelper.java
@@ -287,6 +287,18 @@ public class ItemUpdateHelper {
 					if (infusion == null) {
 						continue;
 					}
+					if (type == InfusionType.AMMUNITION) {
+						String preferredName = ItemStatUtils.getQuiverArrowPreferenceName(item);
+						Component preferredLabel = preferredName == null || preferredName.isBlank()
+							? Component.text("No Preference Set", NamedTextColor.WHITE).decoration(TextDecoration.ITALIC, false)
+							: Component.text(preferredName, NamedTextColor.WHITE).decoration(TextDecoration.ITALIC, false);
+						Component display = type.getDisplay(infusion.getInteger(ItemStatUtils.LEVEL_KEY))
+							.append(Component.text(" (Loading ", NamedTextColor.DARK_GRAY).decoration(TextDecoration.ITALIC, false))
+							.append(preferredLabel)
+							.append(Component.text(")", NamedTextColor.DARK_GRAY).decoration(TextDecoration.ITALIC, false));
+						infusionMap.put(type, display);
+						continue;
+					}
 					if (type.isStatTrackOption()) {
 						if (type == InfusionType.STAT_TRACK_DEATH && ItemUtils.isShulkerBox(item.getType())) {
 							// Easter egg: Times Dyed for shulker boxes

--- a/plugins/paper/src/main/java/com/playmonumenta/plugins/listeners/QuiverListener.java
+++ b/plugins/paper/src/main/java/com/playmonumenta/plugins/listeners/QuiverListener.java
@@ -433,7 +433,7 @@ public class QuiverListener implements Listener {
 		if (!(event.getWhoClicked() instanceof Player player)) {
 			return;
 		}
-		if (!(event.getClick() == ClickType.RIGHT || event.getClick() == ClickType.SWAP_OFFHAND)) {
+		if (event.getClick() != ClickType.RIGHT) {
 			return;
 		}
 		if (!(event.getClickedInventory() instanceof PlayerInventory)) {
@@ -446,7 +446,8 @@ public class QuiverListener implements Listener {
 		if (!isProjectileWeapon(item) || !ItemStatUtils.hasInfusion(item, InfusionType.AMMUNITION)) {
 			return;
 		}
-		if (event.getClick() == ClickType.SWAP_OFFHAND) {
+		ItemStack cursor = event.getCursor();
+		if (ItemUtils.isNullOrAir(cursor)) {
 			ItemStatUtils.setQuiverArrowPreference(item, null);
 			ItemUpdateHelper.generateItemStats(item);
 			player.sendMessage(Component.text("Preferred arrow cleared.", NamedTextColor.GOLD));
@@ -454,7 +455,6 @@ public class QuiverListener implements Listener {
 			event.setCancelled(true);
 			return;
 		}
-		ItemStack cursor = event.getCursor();
 		if (!ItemUtils.isArrow(cursor) || ItemStatUtils.isQuiver(cursor)) {
 			return;
 		}

--- a/plugins/paper/src/main/java/com/playmonumenta/plugins/listeners/QuiverListener.java
+++ b/plugins/paper/src/main/java/com/playmonumenta/plugins/listeners/QuiverListener.java
@@ -7,6 +7,7 @@ import com.playmonumenta.plugins.inventories.CustomContainerItemGui;
 import com.playmonumenta.plugins.inventories.CustomContainerItemManager;
 import com.playmonumenta.plugins.itemstats.enchantments.Multiload;
 import com.playmonumenta.plugins.itemstats.enums.EnchantmentType;
+import com.playmonumenta.plugins.itemstats.enums.InfusionType;
 import com.playmonumenta.plugins.itemupdater.ItemUpdateHelper;
 import com.playmonumenta.plugins.utils.DelveInfusionUtils;
 import com.playmonumenta.plugins.utils.FastUtils;
@@ -53,10 +54,12 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityShootBowEvent;
 import org.bukkit.event.entity.ProjectileLaunchEvent;
 import org.bukkit.event.inventory.ClickType;
+import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.player.PlayerAttemptPickupItemEvent;
 import org.bukkit.event.player.PlayerPickupArrowEvent;
 import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.PlayerInventory;
 import org.bukkit.inventory.meta.CrossbowMeta;
 import org.bukkit.inventory.meta.PotionMeta;
 import org.bukkit.potion.PotionEffect;
@@ -255,7 +258,7 @@ public class QuiverListener implements Listener {
 				ArrowConsumeEvent arrowConsumeEvent = new ArrowConsumeEvent(player, item);
 				Bukkit.getPluginManager().callEvent(arrowConsumeEvent);
 				return !arrowConsumeEvent.isCancelled();
-			});
+			}, event.getBow());
 			if (projectile == null) {
 				event.setCancelled(true);
 				return;
@@ -326,7 +329,7 @@ public class QuiverListener implements Listener {
 				int numProjectiles = 1 + ItemStatUtils.getEnchantmentLevel(crossbow, EnchantmentType.MULTILOAD);
 
 				// Crossbows refund arrows when being shot instead of not consuming arrows when being loaded
-				Pair<ItemStack, Boolean> projectile = takeFromQuiver(player, quiver, numProjectiles, is -> true);
+				Pair<ItemStack, Boolean> projectile = takeFromQuiver(player, quiver, numProjectiles, is -> true, crossbow);
 				if (projectile == null) {
 					return;
 				}
@@ -353,7 +356,7 @@ public class QuiverListener implements Listener {
 		}
 	}
 
-	private @Nullable Pair<ItemStack, Boolean> takeFromQuiver(Player player, ItemStack quiver, int numProjectiles, Predicate<ItemStack> consumePredicate) {
+	private @Nullable Pair<ItemStack, Boolean> takeFromQuiver(Player player, ItemStack quiver, int numProjectiles, Predicate<ItemStack> consumePredicate, @Nullable ItemStack weapon) {
 		if (quiver.getAmount() != 1) {
 			player.sendMessage(Component.text("Cannot use stacked quivers!", NamedTextColor.RED));
 			player.playSound(player.getLocation(), Sound.ENTITY_ARROW_HIT_PLAYER, SoundCategory.PLAYERS, 1, 1);
@@ -361,6 +364,17 @@ public class QuiverListener implements Listener {
 		}
 		if (!getQuiverConfig(quiver).checkCanUse(player)) {
 			return null;
+		}
+		String preferredArrowName = getPreferredArrowNameFromWeapon(weapon);
+		if (preferredArrowName != null) {
+			boolean requireFullAmount = numProjectiles > 1;
+			if (!requireFullAmount || countInQuiver(quiver, preferredArrowName) >= numProjectiles) {
+				Pair<ItemStack, Boolean> preferredResult = CustomContainerItemManager.removeFirstFromContainer(quiver, numProjectiles,
+					item -> ItemUtils.isArrow(item) && ItemUtils.getPlainNameOrDefault(item).equals(preferredArrowName), consumePredicate);
+				if (preferredResult != null) {
+					return preferredResult;
+				}
+			}
 		}
 		Pair<ItemStack, Boolean> result = CustomContainerItemManager.removeFirstFromContainer(quiver, numProjectiles, ItemUtils::isArrow, consumePredicate);
 		if (result == null) {
@@ -371,11 +385,89 @@ public class QuiverListener implements Listener {
 		return result;
 	}
 
+	private @Nullable String getPreferredArrowNameFromWeapon(@Nullable ItemStack weapon) {
+		if (ItemUtils.isNullOrAir(weapon) || !ItemStatUtils.hasInfusion(weapon, InfusionType.AMMUNITION)) {
+			return null;
+		}
+		String preferredArrowName = ItemStatUtils.getQuiverArrowPreferenceName(weapon);
+		if (preferredArrowName == null || preferredArrowName.isBlank()) {
+			return null;
+		}
+		return preferredArrowName;
+	}
+
+	private long countInQuiver(ItemStack quiver, String preferredArrowName) {
+		return NBT.get(quiver, nbt -> {
+			ReadableNBTList<ReadWriteNBT> itemsList = ItemStatUtils.getItemList(nbt);
+			if (itemsList == null) {
+				return 0L;
+			}
+			for (ReadWriteNBT compound : itemsList) {
+				ItemStack containedItem = NBT.itemStackFromNBT(compound);
+				if (containedItem == null) {
+					continue;
+				}
+				NBT.modify(containedItem, ItemStatUtils::removePlayerModified);
+				if (!ItemUtils.isArrow(containedItem) || !ItemUtils.getPlainNameOrDefault(containedItem).equals(preferredArrowName)) {
+					continue;
+				}
+				ReadableNBT playerModified = ItemStatUtils.getPlayerModified(compound.getCompound("tag"));
+				if (playerModified == null) {
+					return 0L;
+				}
+				return playerModified.getLong(CustomContainerItemManager.AMOUNT_KEY);
+			}
+			return 0L;
+		});
+	}
+
 	@EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
 	public void blockPreDispenseEvent(BlockPreDispenseEvent event) {
 		if (event.getBlock().getType() == Material.DISPENSER && ItemStatUtils.isQuiver(event.getItemStack())) {
 			event.setCancelled(true);
 		}
+	}
+
+	@EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
+	public void inventoryClickEvent(InventoryClickEvent event) {
+		if (!(event.getWhoClicked() instanceof Player player)) {
+			return;
+		}
+		if (!(event.getClick() == ClickType.RIGHT || event.getClick() == ClickType.SWAP_OFFHAND)) {
+			return;
+		}
+		if (!(event.getClickedInventory() instanceof PlayerInventory)) {
+			return;
+		}
+		ItemStack item = event.getCurrentItem();
+		if (ItemUtils.isNullOrAir(item) || item.getAmount() != 1) {
+			return;
+		}
+		if (!isProjectileWeapon(item) || !ItemStatUtils.hasInfusion(item, InfusionType.AMMUNITION)) {
+			return;
+		}
+		if (event.getClick() == ClickType.SWAP_OFFHAND) {
+			ItemStatUtils.setQuiverArrowPreference(item, null);
+			ItemUpdateHelper.generateItemStats(item);
+			player.sendMessage(Component.text("Preferred arrow cleared.", NamedTextColor.GOLD));
+			player.playSound(player.getLocation(), Sound.BLOCK_NOTE_BLOCK_BELL, SoundCategory.PLAYERS, 0.8f, 0.9f);
+			event.setCancelled(true);
+			return;
+		}
+		ItemStack cursor = event.getCursor();
+		if (!ItemUtils.isArrow(cursor) || ItemStatUtils.isQuiver(cursor)) {
+			return;
+		}
+
+		ItemStatUtils.setQuiverArrowPreference(item, cursor);
+		ItemUpdateHelper.generateItemStats(item);
+		player.sendMessage(Component.text("Preferred arrow set to " + ItemUtils.getPlainNameOrDefault(cursor) + ".", NamedTextColor.GOLD));
+		player.playSound(player.getLocation(), Sound.BLOCK_NOTE_BLOCK_BELL, SoundCategory.PLAYERS, 0.8f, 1.2f);
+		event.setCancelled(true);
+	}
+
+	private boolean isProjectileWeapon(ItemStack item) {
+		return item.getType() == Material.BOW || item.getType() == Material.CROSSBOW;
 	}
 
 	@EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)

--- a/plugins/paper/src/main/java/com/playmonumenta/plugins/listeners/QuiverListener.java
+++ b/plugins/paper/src/main/java/com/playmonumenta/plugins/listeners/QuiverListener.java
@@ -365,7 +365,7 @@ public class QuiverListener implements Listener {
 		if (!getQuiverConfig(quiver).checkCanUse(player)) {
 			return null;
 		}
-		String preferredArrowName = getPreferredArrowNameFromWeapon(weapon);
+		String preferredArrowName = ItemStatUtils.getQuiverArrowPreferenceName(weapon);
 		if (preferredArrowName != null) {
 			boolean requireFullAmount = numProjectiles > 1;
 			if (!requireFullAmount || countInQuiver(quiver, preferredArrowName) >= numProjectiles) {
@@ -385,17 +385,6 @@ public class QuiverListener implements Listener {
 		return result;
 	}
 
-	private @Nullable String getPreferredArrowNameFromWeapon(@Nullable ItemStack weapon) {
-		if (ItemUtils.isNullOrAir(weapon) || !ItemStatUtils.hasInfusion(weapon, InfusionType.AMMUNITION)) {
-			return null;
-		}
-		String preferredArrowName = ItemStatUtils.getQuiverArrowPreferenceName(weapon);
-		if (preferredArrowName == null || preferredArrowName.isBlank()) {
-			return null;
-		}
-		return preferredArrowName;
-	}
-
 	private long countInQuiver(ItemStack quiver, String preferredArrowName) {
 		return NBT.get(quiver, nbt -> {
 			ReadableNBTList<ReadWriteNBT> itemsList = ItemStatUtils.getItemList(nbt);
@@ -407,7 +396,6 @@ public class QuiverListener implements Listener {
 				if (containedItem == null) {
 					continue;
 				}
-				NBT.modify(containedItem, ItemStatUtils::removePlayerModified);
 				if (!ItemUtils.isArrow(containedItem) || !ItemUtils.getPlainNameOrDefault(containedItem).equals(preferredArrowName)) {
 					continue;
 				}
@@ -443,7 +431,7 @@ public class QuiverListener implements Listener {
 		if (ItemUtils.isNullOrAir(item) || item.getAmount() != 1) {
 			return;
 		}
-		if (!isProjectileWeapon(item) || !ItemStatUtils.hasInfusion(item, InfusionType.AMMUNITION)) {
+		if (!ItemUtils.isSomeBow(item) || !ItemStatUtils.hasInfusion(item, InfusionType.AMMUNITION)) {
 			return;
 		}
 		ItemStack cursor = event.getCursor();
@@ -464,10 +452,6 @@ public class QuiverListener implements Listener {
 		player.sendMessage(Component.text("Preferred arrow set to " + ItemUtils.getPlainNameOrDefault(cursor) + ".", NamedTextColor.GOLD));
 		player.playSound(player.getLocation(), Sound.BLOCK_NOTE_BLOCK_BELL, SoundCategory.PLAYERS, 0.8f, 1.2f);
 		event.setCancelled(true);
-	}
-
-	private boolean isProjectileWeapon(ItemStack item) {
-		return item.getType() == Material.BOW || item.getType() == Material.CROSSBOW;
 	}
 
 	@EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)

--- a/plugins/paper/src/main/java/com/playmonumenta/plugins/utils/ItemStatUtils.java
+++ b/plugins/paper/src/main/java/com/playmonumenta/plugins/utils/ItemStatUtils.java
@@ -81,6 +81,7 @@ public class ItemStatUtils {
 	public static final String CUSTOM_INVENTORY_ITEMS_PER_TYPE_LIMIT_KEY = "CustomInventoryItemsPerTypeLimit";
 	public static final String IS_QUIVER_KEY = "IsQuiver";
 	public static final String QUIVER_ARROW_TRANSFORM_MODE_KEY = "ArrowTransformMode";
+	public static final String AMMUNITION_PREFERRED_ARROW_NAME_KEY = "PreferredArrowName";
 	public static final String CHARGES_KEY = "Charges";
 	public static final String ITEMS_KEY = "Items";
 	public static final String VANITY_ITEMS_KEY = "VanityItems";
@@ -1384,6 +1385,45 @@ public class ItemStatUtils {
 	public static QuiverListener.ArrowTransformMode getArrowTransformMode(ItemStack item) {
 		return NBT.get(item, nbt -> {
 			return nbt.resolveOrDefault(MONUMENTA_KEY + "." + PLAYER_MODIFIED_KEY + "." + QUIVER_ARROW_TRANSFORM_MODE_KEY, QuiverListener.ArrowTransformMode.NONE);
+		});
+	}
+
+	public static void setQuiverArrowPreference(@Nullable ItemStack item, @Nullable ItemStack preferredArrow) {
+		if (ItemUtils.isNullOrAir(item) || !hasInfusion(item, InfusionType.AMMUNITION)) {
+			return;
+		}
+		NBT.modify(item, nbt -> {
+			ReadWriteNBT infusion = addPlayerModified(nbt)
+				.getOrCreateCompound(InfusionType.KEY)
+				.getOrCreateCompound(InfusionType.AMMUNITION.getName());
+			if (ItemUtils.isNullOrAir(preferredArrow)) {
+				infusion.removeKey(AMMUNITION_PREFERRED_ARROW_NAME_KEY);
+				return;
+			}
+			String preferenceName = ItemUtils.getPlainNameOrDefault(preferredArrow);
+			if (preferenceName == null || preferenceName.isBlank()) {
+				infusion.removeKey(AMMUNITION_PREFERRED_ARROW_NAME_KEY);
+				return;
+			}
+			infusion.setString(AMMUNITION_PREFERRED_ARROW_NAME_KEY, preferenceName);
+		});
+	}
+
+	public static @Nullable String getQuiverArrowPreferenceName(@Nullable ItemStack item) {
+		if (ItemUtils.isNullOrAir(item)) {
+			return null;
+		}
+		return NBT.get(item, nbt -> {
+			ReadableNBT infusions = getInfusions(nbt);
+			if (infusions == null) {
+				return null;
+			}
+			ReadableNBT infusion = infusions.getCompound(InfusionType.AMMUNITION.getName());
+			if (infusion == null) {
+				return null;
+			}
+			String stored = infusion.getString(AMMUNITION_PREFERRED_ARROW_NAME_KEY);
+			return stored == null || stored.isBlank() ? null : stored;
 		});
 	}
 


### PR DESCRIPTION
This is my implementation of QoL Suggestion #14174 for bows and crossbows to preference their ammo when drawing from a player's Quiver. Implementation subject to developers' approval, of course, but I hope this code may be given consideration.

Details subject to change: I've coded an infusion titled "ammunition." Once applied onto a bow or crossbow, a player can right-click an arrow item into it to set the preferred ammo. The ammo is stored as a plain name in the infusion. Any time a quiver arrow retrieval is triggered, takeFromQuiver tries to find the corresponding plain name from the quiver (and checks for multiload). It will default back to taking the first arrow out of the quiver if no corresponding ammo is found.

Swap hands while hovering over the bow or crossbow will clear the selection and allow it to function as normal.

I don't have the environment to test this code on my end. If any plugin devs are interested, I'd love to work with you to make this infusion, or some version of this logic, a reality.