### PR TITLE
Fix fish-specific bait quality bug

### DIFF
--- a/plugins/paper/src/main/java/com/playmonumenta/plugins/bosses/bosses/aurora/Aurora.java
+++ b/plugins/paper/src/main/java/com/playmonumenta/plugins/bosses/bosses/aurora/Aurora.java
@@ -222,7 +222,7 @@ public class Aurora extends SerializedLocationBossAbilityGroup {
 		if (mRage >= 100) {
 			phase2Actives.add(new SpellStardustDetonation(plugin, boss, spawnLoc, 7, mRage >= 200 ? this::destroyBlocksHarsh : this::destroyBlocks));
 			phase3Actives.add(new SpellStardustDetonation(plugin, boss, spawnLoc, 7, mRage >= 200 ? this::destroyBlocksHarsh : this::destroyBlocks));
-			phase4Actives.add(new SpellStardustDetonation(plugin, boss, spawnLoc, mRage >= 200 ? 3 : 4.5, this::destroyBlocks));
+			phase4Actives.add(new SpellStardustDetonation(plugin, boss, spawnLoc, mRage >= 200 ? 5 : 4, this::destroyBlocks));
 		}
 		if (mRage >= 160) {
 			phase1Actives.add(rageStarShower);

--- a/plugins/paper/src/main/java/com/playmonumenta/plugins/bosses/spells/aurora/SpellAuroraMobs.java
+++ b/plugins/paper/src/main/java/com/playmonumenta/plugins/bosses/spells/aurora/SpellAuroraMobs.java
@@ -46,7 +46,7 @@ public class SpellAuroraMobs extends Spell {
 		}
 		mSpellCooldownManager.setOnCooldown();
 
-		for (int i = 0; i < (mRage >= 200 ? NORMAL_COUNT : NORMAL_COUNT_200_RAGE); i++) {
+		for (int i = 0; i < (mRage >= 200 ? NORMAL_COUNT_200_RAGE : NORMAL_COUNT); i++) {
 			spawnMob();
 		}
 	}


### PR DESCRIPTION
Fixes the bug #21444 from discord.
The bug is where fish-specific bait will have quality fail to apply to the fish that the bait applies for when it is caught using the fish-specific table.
I believe the issue was a reference issue involving the reassignment of caughtItemStack and setting caughtItem's item stack. 
Thus the quality function was given an item stack that was dereferenced from the caughtItem item stack and editing it did nothing to the item given to the player. 
Explaining why the quality and t5 particles showed up when getting a t1 fish and t4 fish respectively.

I have tested this on a local sdk using the base fishing loot table being just t1 flounder and t1 mungfish.  The fish-specific bait was for Prismatic Cod and the fish-specific bait loot table was just a t1 prismatic cod.

There are likely better ways of resolving the bug, but this works, should have no side-effects, and I do not know what fishing updates there will be.